### PR TITLE
Refactor, SentinelOne support, and miscellaneous improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,28 @@ ENV/
 # Project things
 *.csv
 .carbonblack
+
+# PyCharm
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+.idea/dictionaries
+.idea/vcs.xml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ ENV/
 .idea/mongoSettings.xml
 
 .idea/
+
+# other
+logs/

--- a/README.md
+++ b/README.md
@@ -15,16 +15,31 @@ Surveyor currently supports the following EDR platforms:
 - VMware Carbon Black® (Cb) Enterprise Response
 - VMware Carbon Black Cloud Enterprise EDR (formerly Carbon Black ThreatHunter)
 - Microsoft Defender for Endpoint
+- SentinelOne
 
 You can find out more about Surveyor from [this blog post](https://redcanary.com/blog/carbon-black-response-how-tos-surveyor/).
 
 ## Get started
 
 For information about installing and using Surveyor, see the [Getting started](https://github.com/redcanaryco/surveyor/wiki/Getting-started)
-page of the wiki.
+page of the wiki. Surveyor requires Python 3.9+.
 
 ## Contribute to Surveyor
 
 We encourage and welcome your contributions to Surveyor. For more information,
 see the [Contributing to Surveyor](https://github.com/redcanaryco/surveyor/wiki/Contributing-to-Surveyor)
 page of the wiki.
+
+## Query Samples
+
+#### Running the `sysinternals` definition file using the `cbr` product:
+
+```
+surveyor.py --deffile sysinternals cbr
+```
+
+#### Running the `sysinternals` definition file using the `dfe` product:
+
+```
+surveyor.py --deffile sysinternals dfe --creds dfe_creds.ini
+```

--- a/common.py
+++ b/common.py
@@ -1,11 +1,14 @@
-import csv
 import logging
 from abc import ABC, abstractmethod
+from typing import Tuple, Optional, Any, Union
+
+from help import log_echo
 
 
 class Product(ABC):
     product: str = None  # a string describing the product (e.g. cbr/cbth/defender/s1)
     profile: str  # the profile is used to authenticate to the target platform
+    _results: dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]
     log: logging.Logger
 
     def __init__(self, product, profile):
@@ -17,41 +20,70 @@ class Product(ABC):
         if not self.profile:
             self.profile = 'default'
 
+        self._results = dict()
+
         self.log.debug(f'Authenticating to {self.product}')
         self._authenticate()
         self.log.debug(f'Authenticated')
 
     @abstractmethod
-    def _authenticate(self):
+    def _authenticate(self) -> None:
         """
         Authenticate to the target product API.
         """
         raise NotImplementedError()
 
     # noinspection PyMethodMayBeStatic
-    def base_query(self):
+    def base_query(self) -> dict:
         """
         Get base query parameters for the product.
         """
         return dict()
 
     @abstractmethod
-    def build_query(self, filters: dict):
+    def build_query(self, filters: dict) -> Any:
         """
         Build a base query for the product.
         """
         raise NotImplementedError()
 
     @abstractmethod
-    def process_search(self, base_query, query):
+    def process_search(self, tag: Union[str, Tuple], base_query: dict, query: str) -> None:
         """
         Perform a process search.
         """
         raise NotImplementedError()
 
     @abstractmethod
-    def nested_process_search(self, criteria, base_query):
+    def nested_process_search(self, tag: Union[str, Tuple], criteria: dict, base_query: dict) -> None:
         """
         Performed a nested process search.
         """
         raise NotImplementedError()
+
+    def get_results(self) -> dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]:
+        """
+        Get results from all process_search and nested_process_search calls.
+
+        :returns: A dictionary whose keys represent the tags used to identify searches. The dictionary values
+        are lists containing the search results as tuples with members: hostname, username, path, command_line.
+        """
+        return self._results
+
+    def _add_results(self, results: list[Tuple[str, str, str, str]], tag: Optional[str] = None):
+        """
+        Add results to the result store.
+        """
+        if not tag:
+            tag = '_default'
+
+        if tag not in self._results:
+            self._results[tag] = list()
+
+        self._results[tag].extend(results)
+
+    def _echo(self, message: str, level: int = logging.DEBUG):
+        """
+        Write a message to STDOUT and the debug log stream.
+        """
+        log_echo(message, self.log, level)

--- a/common.py
+++ b/common.py
@@ -12,7 +12,7 @@ class Product(ABC):
     log: logging.Logger
     _tqdm_echo: bool = False
 
-    def __init__(self, product, profile, tqdm_echo: bool = False):
+    def __init__(self, product, profile, tqdm_echo: bool = False, **kwargs):
         self.profile = profile
         self.product = product
         self._tqdm_echo = tqdm_echo

--- a/common.py
+++ b/common.py
@@ -6,6 +6,11 @@ from help import log_echo
 
 
 class Product(ABC):
+    """
+    Base class for surveyor product implementations.
+
+    Subclasses must implement all abstract methods and invoke this class's constructor.
+    """
     product: str = None  # a string describing the product (e.g. cbr/cbth/defender/s1)
     profile: str  # the profile is used to authenticate to the target platform
     _results: dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]

--- a/common.py
+++ b/common.py
@@ -61,6 +61,18 @@ class Product(ABC):
         """
         raise NotImplementedError()
 
+    def has_results(self) -> bool:
+        """
+        Test whether product has any search results.
+        """
+        return len(self._results) > 0
+
+    def clear_results(self) -> None:
+        """
+        Clear all stored results.
+        """
+        self._results.clear()
+
     def get_results(self) -> dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]:
         """
         Get results from all process_search and nested_process_search calls.

--- a/common.py
+++ b/common.py
@@ -10,10 +10,12 @@ class Product(ABC):
     profile: str  # the profile is used to authenticate to the target platform
     _results: dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]
     log: logging.Logger
+    _tqdm_echo: bool = False
 
-    def __init__(self, product, profile):
+    def __init__(self, product, profile, tqdm_echo: bool = False):
         self.profile = profile
         self.product = product
+        self._tqdm_echo = tqdm_echo
 
         self.log = logging.getLogger(f'surveyor.{self.product}')
 
@@ -73,9 +75,12 @@ class Product(ABC):
         """
         self._results.clear()
 
-    def get_results(self) -> dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]:
+    def get_results(self, final_call: bool = True) -> dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]:
         """
         Get results from all process_search and nested_process_search calls.
+
+        :param final_call: Indicates whether this is the final time get_results will be called for this
+        set of process searches.
 
         :returns: A dictionary whose keys represent the tags used to identify searches. The dictionary values
         are lists containing the search results as tuples with members: hostname, username, path, command_line.
@@ -98,4 +103,4 @@ class Product(ABC):
         """
         Write a message to STDOUT and the debug log stream.
         """
-        log_echo(message, self.log, level)
+        log_echo(message, self.log, level, use_tqdm=self._tqdm_echo)

--- a/help.py
+++ b/help.py
@@ -2,6 +2,7 @@ import csv
 import logging
 import os
 import re
+from datetime import datetime
 from typing import Iterator, Tuple, Optional
 
 import click
@@ -53,3 +54,10 @@ def write_results(output: Optional[csv.writer], results: list[Tuple[str, str, st
                     row[i] = row[i][:template[i] - 3] + '...'
 
             click.echo(template_str.format(*row))
+
+
+def datetime_to_epoch_millis(date: datetime) -> int:
+    """
+    Convert a datetime object to an epoch timestamp in milliseconds.
+    """
+    return int((date - datetime.utcfromtimestamp(0)).total_seconds() * 1000)

--- a/help.py
+++ b/help.py
@@ -38,7 +38,7 @@ def log_echo(message: str, log: logging.Logger, level: int = logging.DEBUG, use_
         click.echo(color_message)
 
     # strip ANSI sequences from log string
-    log.log(level, message)
+    log.log(level, _strip_ansi_codes(message))
 
 
 def write_results(output: Optional[csv.writer], results: list[Tuple[str, str, str, str]], program: str, source: str,

--- a/help.py
+++ b/help.py
@@ -9,6 +9,8 @@ import click
 
 
 # regular expression that detects ANSI color codes
+from tqdm import tqdm
+
 ansi_escape_regex = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', re.VERBOSE)
 
 
@@ -19,7 +21,7 @@ def _strip_ansi_codes(message: str) -> str:
     return ansi_escape_regex.sub('', message)
 
 
-def log_echo(message: str, log: logging.Logger, level: int = logging.DEBUG):
+def log_echo(message: str, log: logging.Logger, level: int = logging.DEBUG, use_tqdm: bool = False):
     """
     Write a command to STDOUT and the debug log stream.
     """
@@ -30,7 +32,10 @@ def log_echo(message: str, log: logging.Logger, level: int = logging.DEBUG):
     elif level >= logging.ERROR:
         color_message = f'\u001b[31m{color_message}\u001b[0m'
 
-    click.echo(color_message)
+    if use_tqdm:
+        tqdm.write(color_message)
+    else:
+        click.echo(color_message)
 
     # strip ANSI sequences from log string
     log.log(level, message)

--- a/help.py
+++ b/help.py
@@ -1,3 +1,7 @@
+import os
+from pathlib import Path
+from typing import Iterator
+
 from common import Product
 
 
@@ -9,10 +13,6 @@ for module in os.listdir(os.path.join(os.path.dirname(__file__), 'products')):
         continue
     __import__('products.' + module[:-3], locals(), globals())
     del module
-
-
-# regular expression that detects ANSI color codes
-ansi_escape_regex = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', re.VERBOSE)
 
 
 def _get_subclasses():

--- a/help.py
+++ b/help.py
@@ -44,7 +44,7 @@ def log_echo(message: str, log: logging.Logger, level: int = logging.DEBUG, use_
 def write_results(output: Optional[csv.writer], results: list[Tuple[str, str, str, str]], program: str, source: str,
                   template: Tuple[int, int, int, int, int, int] = (20, 20, 20, 20, 20, 20)):
     """
-    Write results to output CSV.
+    Write results to output CSV or STDOUT.
     """
     template_str = f'{{:<{template[0]}}} {{:<{template[1]}}} {{:<{template[2]}}} {{:<{template[3]}}}'
     for hostname, username, path, command_line in results:

--- a/help.py
+++ b/help.py
@@ -1,13 +1,8 @@
-import csv
 import logging
-import os
 import re
 from datetime import datetime
-from typing import Iterator, Tuple, Optional
 
 import click
-
-
 # regular expression that detects ANSI color codes
 from tqdm import tqdm
 
@@ -39,26 +34,6 @@ def log_echo(message: str, log: logging.Logger, level: int = logging.DEBUG, use_
 
     # strip ANSI sequences from log string
     log.log(level, _strip_ansi_codes(message))
-
-
-def write_results(output: Optional[csv.writer], results: list[Tuple[str, str, str, str]], program: str, source: str,
-                  template: Tuple[int, int, int, int, int, int] = (20, 20, 20, 20, 20, 20)):
-    """
-    Write results to output CSV or STDOUT.
-    """
-    template_str = f'{{:<{template[0]}}} {{:<{template[1]}}} {{:<{template[2]}}} {{:<{template[3]}}}'
-    for hostname, username, path, command_line in results:
-        row = [hostname, username, path, command_line, program, source]
-        
-        if output:
-            output.writerow(row)
-        else:
-            # trim data to make sure it fits into table format
-            for i in range(len(row)):
-                if len(row[i]) > template[i]:
-                    row[i] = row[i][:template[i] - 3] + '...'
-
-            click.echo(template_str.format(*row))
 
 
 def datetime_to_epoch_millis(date: datetime) -> int:

--- a/load.py
+++ b/load.py
@@ -1,3 +1,7 @@
+import os
+import re
+from typing import Iterator
+
 from common import Product
 
 
@@ -9,10 +13,6 @@ for module in os.listdir(os.path.join(os.path.dirname(__file__), 'products')):
         continue
     __import__('products.' + module[:-3], locals(), globals())
     del module
-
-
-# regular expression that detects ANSI color codes
-ansi_escape_regex = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', re.VERBOSE)
 
 
 def _get_subclasses():

--- a/load.py
+++ b/load.py
@@ -1,13 +1,11 @@
 import os
-import re
-from typing import Iterator
+from typing import Iterator, Type
 
 from common import Product
 
 
 # import all files in the 'products' folder
 # this is required so that Product.__subclasses__() can resolve all implemented subclasses
-# this ensure that new subclasses in 'products' will automatically be picked up
 for module in os.listdir(os.path.join(os.path.dirname(__file__), 'products')):
     if module == '__init__.py' or module[-3:] != '.py':
         continue
@@ -15,10 +13,14 @@ for module in os.listdir(os.path.join(os.path.dirname(__file__), 'products')):
     del module
 
 
-def _get_subclasses():
+def _get_subclasses() -> list[Type[Product]]:
+    """
+    Retrieve all subclasses of the "Product" class.
+    """
     seen = set()
 
     for subclass in Product.__subclasses__():
+        # ensure two products don't have the same product string
         if subclass.product in seen:
             raise ValueError(f'Product {subclass.product} is declared multiple times')
 
@@ -30,7 +32,7 @@ def get_product_instance(product: str, **kwargs) -> Product:
     """
     Get an instance of the product implementation matching the specified product string.
     """
-    for subclass in Product.__subclasses__():
+    for subclass in _get_subclasses():
         if subclass.product == product:
             return subclass(**kwargs)
 

--- a/load.py
+++ b/load.py
@@ -1,0 +1,42 @@
+from typing import Iterator
+
+from common import Product
+
+# these imports must exit for subclass resolution to function
+# new subclasses won't be shown unless they are imported here
+# new subclasses must have the 'product' attribute
+# noinspection PyUnresolvedReferences
+from products import (
+    microsoft_defender_for_endpoints as defender,
+    vmware_cb_enterprise_edr as cbth,
+    vmware_cb_response as cbr
+)
+
+
+def _get_subclasses():
+    seen = set()
+
+    for subclass in Product.__subclasses__():
+        if subclass.product in seen:
+            raise ValueError(f'Product {subclass.product} is declared multiple times')
+
+        seen.add(subclass.product)
+        yield subclass
+
+
+def get_product_instance(product: str, **kwargs) -> Product:
+    """
+    Get an instance of the product implementation matching the specified product string.
+    """
+    for subclass in Product.__subclasses__():
+        if subclass.product == product:
+            return subclass(**kwargs)
+
+    raise ValueError(f'Product {product} is not implemented')
+
+
+def get_products() -> Iterator[str]:
+    """
+    Get a list of all implemented product strings.
+    """
+    return (subclass.product for subclass in _get_subclasses())

--- a/products/microsoft_defender_for_endpoints.py
+++ b/products/microsoft_defender_for_endpoints.py
@@ -68,7 +68,8 @@ class DefenderForEndpoints(Product):
 
             if response.status_code == 200:
                 for res in response.json()["Results"]:
-                    result = Result(res["DeviceName"], res["AccountName"], res["ProcessCommandLine"], res["FolderPath"])
+                    result = Result(res["DeviceName"], res["AccountName"], res["ProcessCommandLine"], res["FolderPath"],
+                                    (res["Timestamp"],))
                     results.add(result)
             else:
                 self._echo(f"Received status code: {response.status_code} (message: {response.json()})")
@@ -90,7 +91,8 @@ class DefenderForEndpoints(Product):
     def process_search(self, tag: Tag, base_query: dict, query: str) -> None:
         query = query + self.build_query(base_query)
 
-        query = "DeviceEvents " + query + " | project DeviceName, AccountName, ProcessCommandLine, FolderPath "
+        query = "DeviceEvents " + query + \
+                " | project DeviceName, AccountName, ProcessCommandLine, FolderPath, Timestamp "
         query = query.rstrip()
 
         self.log.debug(f'Query: {query}')
@@ -127,7 +129,7 @@ class DefenderForEndpoints(Product):
                     continue
 
                 query = "union DeviceEvents, DeviceFileCertificateInfo, DeviceProcessEvents" + query_base + query \
-                        + " | project DeviceName, AccountName, ProcessCommandLine, FolderPath "
+                        + " | project DeviceName, AccountName, ProcessCommandLine, FolderPath, Timestamp "
                 query = query.rstrip()
 
                 self.log.debug(f'Query: {query}')
@@ -156,3 +158,6 @@ class DefenderForEndpoints(Product):
                 self._echo(f'Query filter {key} is not supported by product {self.product}', logging.WARNING)
 
         return query_base
+
+    def get_other_row_headers(self) -> list[str]:
+        return ['Timestamp']

--- a/products/microsoft_defender_for_endpoints.py
+++ b/products/microsoft_defender_for_endpoints.py
@@ -1,119 +1,144 @@
-import csv
-import json
+import configparser
 import os
-import time
-import datetime
-from pprint import pprint
-import click
 
-import urllib.request
-import urllib.parse
-import sys
+import click
 import requests
 
+from common import Product
 
-def build_query(filters):
-    query_base = ''
 
-    for key, value in filters.items():
-        if key == 'days':
-            query_base += f'| where Timestamp > ago({value}d)'
+class DefenderForEndpoints(Product):
+    """
+    Surveyor implementation for product "Microsoft Defender For Endpoint"
+    """
+    product: str = 'defender'
+    creds_file: str  # path to credential configuration file
+    _token: str  # AAD access token
 
-        if key == 'minutes':
-            query_base += f'| where Timestamp > ago({value}m)'
+    def __init__(self, profile: str, creds_file: str):
+        if not os.path.isfile(creds_file):
+            raise ValueError(f'Credential file {creds_file} does not exist')
 
-        if key == 'hostname':
-            query_base += f'| where DeviceName contains "{value}"'
+        self.creds_file = creds_file
 
-        if key == 'username':
-            query_base += f'| where AccountName contains "{value}"'
-    return query_base
+        super().__init__(self.product, profile)
 
-def process_search(conn, base, user_query): 
-    
-    results = set()
+    def _authenticate(self):
+        config = configparser.ConfigParser()
+        config.sections()
+        config.read(self.creds_file)
 
-    url = "https://api.securitycenter.microsoft.com/api/advancedqueries/run"
-    query = "DeviceEvents" + base + user_query + "| project DeviceName, AccountName, ProcessCommandLine, FolderPath"
+        if self.profile not in config:
+            raise ValueError(f'Profile {self.profile} is not present in credential file')
 
-    query_obj = json.dumps({'Query': query}).encode("utf-8")    
-    headers_obj = {
-        "Authorization":"Bearer " + conn, 
-        "Content-Type":"application/json", 
-        "Accept": 'application/json'
-        }
-   
-    try: 
-        response = requests.post(url, data=query_obj, headers=headers_obj)
-    except KeyboardInterrupt: 
-        click.echo("Caught CTRL-C. Rerun surveyor")
-    except Exception as e: 
-        click.echo(f"There was an exception {e}")
+        section = config[self.profile]
+        self._token = self._get_aad_token(section['tenantId'], section['appId'], section['appSecret'])
 
-    if response.status_code == 200: 
-        for res in response.json()["Results"]: 
-            results.add((res["DeviceName"], res["AccountName"], res["ProcessCommandLine"], res["FolderPath"]))
+    def _get_aad_token(self, tenant_id: str, app_id: str, app_secret: str):
+        """
+        Retrieve an authentication token from Azure Active Directory using app ID and secret.
+        """
+        self.log.debug(f'Acquiring AAD access token for tenant {tenant_id} and app {app_id}')
 
-    else: 
-        click.echo(f"We received the following status code {response.status_code}")
-    
-    return results
-
-def nested_process_search(conn, criteria, base):
-    results = set()
-    
-    url = "https://api.securitycenter.microsoft.com/api/advancedqueries/run"
-    headers_obj = {
-        "Authorization":"Bearer " + conn, 
-        "Content-Type":"application/json", 
-        "Accept": 'application/json'
+        body = {
+            "resource": 'https://api.securitycenter.windows.com',
+            "client_id": app_id,
+            "client_secret": app_secret,
+            "grant_type": "client_credentials"
         }
 
-    query_base = build_query(base)
-    try:
-        for search_field, terms in criteria.items():            
-            all_terms = ', '.join(f"'{term}'" for term in terms)
-            if search_field == 'process_name':
-                query = f"| where FileName has_any ({all_terms})"
-            elif search_field == "filemod": 
-                query = f"| where FileName has_any ({all_terms})"
-            elif search_field == "ipaddr":
-                query = f"| where RemoteIP has_any ({all_terms})"
-            elif search_field == "cmdline": 
-                query = f"| where ProcessCommandLine has_any ({all_terms})"
-            elif search_field == "digsig_publisher": 
-                query = f"| where Signer has_any ({all_terms})"
-            elif search_field == "domain":
-                query = f"| where RemoteUrl has_any ({all_terms})"
-            elif search_field == "internal_name":
-                query = f"| where ProcessVersionInfoInternalFileName has_any ({all_terms})"
-            
-            else: 
-                continue
-            
-            query = "union DeviceEvents, DeviceFileCertificateInfo, DeviceProcessEvents" + query_base + query + "| project DeviceName, AccountName, ProcessCommandLine, FolderPath"
+        url = f"https://login.windows.net/{tenant_id}/oauth2/token"
 
+        response = requests.get(url, data=body)
+        response.raise_for_status()
 
-            data = json.dumps({'Query': query}).encode("utf-8")
+        return response.json()['access_token']
 
-            try: 
-                response = requests.post(url, data=data, headers=headers_obj)
-            except KeyboardInterrupt: 
-                click.echo("Caught CTRL-C. Rerun surveyor")
-            except Exception as e: 
-                click.echo(f"There was an exception {e}")
+    def _post_advanced_query(self, data: dict, headers: dict):
+        results = set()
 
-            if response.status_code == 200: 
-                for res in response.json()["Results"]: 
+        try:
+            url = "https://api.securitycenter.microsoft.com/api/advancedqueries/run"
+            response = requests.post(url, data=data, headers=headers)
+
+            if response.status_code == 200:
+                for res in response.json()["Results"]:
                     results.add((res["DeviceName"], res["AccountName"], res["ProcessCommandLine"], res["FolderPath"]))
-            else: 
+            else:
                 click.echo(f"We received the following status code {response.status_code}")
-    
-    except Exception as e:
-        click.echo(e)
-        pass
-    except KeyboardInterrupt:
-        click.echo("Caught CTRL-C. Returning what we have . . .")
+        except KeyboardInterrupt as e:
+            click.echo("Caught CTRL-C. Rerun surveyor")
+            self.log.exception(e)
+        except Exception as e:
+            click.echo(f"There was an exception {e}")
+            self.log.exception(e)
 
-    
-    return results
+        return results
+
+    def _get_default_header(self):
+        return {
+            "Authorization": 'Bearer ' + self._token,
+            "Content-Type": 'application/json',
+            "Accept": 'application/json'
+        }
+
+    def process_search(self, base_query, query):
+        query = "DeviceEvents" + base_query + query + "| project DeviceName, AccountName, ProcessCommandLine, " \
+                                                      "FolderPath "
+        query = {'Query': query}
+
+        return self._post_advanced_query(data=query, headers=self._get_default_header())
+
+    def nested_process_search(self, criteria, base_query):
+        results = set()
+
+        query_base = self.build_query(base_query)
+
+        try:
+            for search_field, terms in criteria.items():
+                all_terms = ', '.join(f"'{term}'" for term in terms)
+                if search_field == 'process_name':
+                    query = f"| where FileName has_any ({all_terms})"
+                elif search_field == "filemod":
+                    query = f"| where FileName has_any ({all_terms})"
+                elif search_field == "ipaddr":
+                    query = f"| where RemoteIP has_any ({all_terms})"
+                elif search_field == "cmdline":
+                    query = f"| where ProcessCommandLine has_any ({all_terms})"
+                elif search_field == "digsig_publisher":
+                    query = f"| where Signer has_any ({all_terms})"
+                elif search_field == "domain":
+                    query = f"| where RemoteUrl has_any ({all_terms})"
+                elif search_field == "internal_name":
+                    query = f"| where ProcessVersionInfoInternalFileName has_any ({all_terms})"
+                else:
+                    continue
+
+                query = "union DeviceEvents, DeviceFileCertificateInfo, DeviceProcessEvents" + query_base + query \
+                        + "| project DeviceName, AccountName, ProcessCommandLine, FolderPath "
+                data = {'Query': query}
+
+                for entry in self._post_advanced_query(data=data, headers=self._get_default_header()):
+                    results.add(entry)
+        except KeyboardInterrupt:
+            click.echo("Caught CTRL-C. Returning what we have...")
+
+        return results
+
+    def build_query(self, filters: dict) -> str:
+        query_base = ''
+
+        for key, value in filters.items():
+            if key == 'days':
+                query_base += f'| where Timestamp > ago({value}d)'
+
+            if key == 'minutes':
+                query_base += f'| where Timestamp > ago({value}m)'
+
+            if key == 'hostname':
+                query_base += f'| where DeviceName contains "{value}"'
+
+            if key == 'username':
+                query_base += f'| where AccountName contains "{value}"'
+
+        return query_base

--- a/products/microsoft_defender_for_endpoints.py
+++ b/products/microsoft_defender_for_endpoints.py
@@ -16,13 +16,13 @@ class DefenderForEndpoints(Product):
     creds_file: str  # path to credential configuration file
     _token: str  # AAD access token
 
-    def __init__(self, profile: str, creds_file: str):
+    def __init__(self, profile: str, creds_file: str, **kwargs):
         if not os.path.isfile(creds_file):
             raise ValueError(f'Credential file {creds_file} does not exist')
 
         self.creds_file = creds_file
 
-        super().__init__(self.product, profile)
+        super().__init__(self.product, profile, **kwargs)
 
     def _authenticate(self):
         config = configparser.ConfigParser()

--- a/products/microsoft_defender_for_endpoints.py
+++ b/products/microsoft_defender_for_endpoints.py
@@ -12,7 +12,7 @@ class DefenderForEndpoints(Product):
     """
     Surveyor implementation for product "Microsoft Defender For Endpoint"
     """
-    product: str = 'defender'
+    product: str = 'dfe'
     creds_file: str  # path to credential configuration file
     _token: str  # AAD access token
 

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -476,12 +476,11 @@ class SentinelOne(Product):
 
                 self._results[merged_tag] = list()
                 for event in events:
-                    # event_time = event['eventTime']
                     hostname = event['endpointName']
                     username = event['srcProcUser']
                     path = event['processImagePath']
                     command_line = event['srcProcCmdLine']
-                    additional_data = (event['siteId'], event['siteName'])
+                    additional_data = (event['eventTime'], event['siteId'], event['siteName'])
 
                     result = Result(hostname, username, path, command_line, additional_data)
                     self._results[merged_tag].append(result)
@@ -501,4 +500,4 @@ class SentinelOne(Product):
         return self._results
 
     def get_other_row_headers(self) -> list[str]:
-        return ['Site ID', 'Site Name']
+        return ['Event Time', 'Site ID', 'Site Name']

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -250,7 +250,7 @@ class SentinelOne(Product):
 
                 self._queries[tag].append((from_date, to_date, query))
 
-                if len(self._queries) == 10:
+                if sum(len(x) for x in self._queries.values()) == 10:
                     self._process_queries()
         except KeyboardInterrupt:
             self._echo("Caught CTRL-C. Returning what we have...")

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -227,6 +227,12 @@ class SentinelOne(Product):
         except KeyboardInterrupt:
             self._echo("Caught CTRL-C. Returning what we have...")
 
+    def has_results(self) -> bool:
+        return False
+
+    def clear_results(self) -> None:
+        return
+
     def get_results(self) -> dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]:
         self.log.debug('Entered get_results')
 

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -27,7 +27,7 @@ class SentinelOne(Product):
     _queries: dict[str, list[Tuple[datetime, datetime, str]]]
     _last_request: float
 
-    def __init__(self, profile: str, creds_file: str):
+    def __init__(self, profile: str, creds_file: str, **kwargs):
         if not os.path.isfile(creds_file):
             raise ValueError(f'Credential file {creds_file} does not exist')
 
@@ -36,7 +36,7 @@ class SentinelOne(Product):
 
         self._last_request = 0.0
 
-        super().__init__(self.product, profile)
+        super().__init__(self.product, profile, **kwargs)
 
     def _authenticate(self):
         config = configparser.ConfigParser()

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -132,7 +132,7 @@ class SentinelOne(Product):
         # therefore we return the from/to dates separately
         return query_base, from_date, to_date
 
-    def _get_all_paginated_data(self, response: requests.Response,key='data') -> list[dict]:
+    def _get_all_paginated_data(self, response: requests.Response, key='data') -> list[dict]:
         """
         Get and return all paginated data from the response, making additional queries if necessary.
         """

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -469,7 +469,7 @@ class SentinelOne(Product):
                     username = event['srcProcUser']
                     path = event['processImagePath']
                     command_line = event['srcProcCmdLine']
-                    additional_data = (event['siteId'])
+                    additional_data = (event['siteId'], event['siteName'])
 
                     result = Result(hostname, username, path, command_line, additional_data)
                     self._results[merged_tag].append(result)
@@ -489,4 +489,4 @@ class SentinelOne(Product):
         return self._results
 
     def get_other_row_headers(self) -> list[str]:
-        return ['Site ID']
+        return ['Site ID', 'Site Name']

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -1,0 +1,307 @@
+import configparser
+import json
+import logging
+import os
+import time
+from datetime import datetime, timedelta
+from typing import Optional, Tuple, Union
+
+import requests
+from requests.adapters import HTTPAdapter
+
+from common import Product
+
+
+def _get_epoch_millis(date: datetime) -> int:
+    return int((date - datetime.utcfromtimestamp(0)).total_seconds() * 1000)
+
+
+class SentinelOne(Product):
+    """
+    Surveyor implementation for product "SentinelOne"
+    """
+    product: str = 's1'
+    creds_file: str  # path to credential configuration file
+    _token: str  # AAD access token
+    _url: str  # URL of SentinelOne console
+    _site_id: Optional[str]  # Site ID for SentinelOne
+    _account_id: Optional[str]  # Account ID for SentinelOne
+    _session: requests.Session
+    _queries: dict[str, list[Tuple[datetime, datetime, str]]]
+
+    def __init__(self, profile: str, creds_file: str):
+        if not os.path.isfile(creds_file):
+            raise ValueError(f'Credential file {creds_file} does not exist')
+
+        self.creds_file = creds_file
+        self._queries = dict()
+
+        super().__init__(self.product, profile)
+
+    def _authenticate(self):
+        config = configparser.ConfigParser()
+        config.read(self.creds_file)
+
+        if self.profile not in config:
+            raise ValueError(f'Profile {self.profile} is not present in credential file')
+
+        section = config[self.profile]
+
+        # ensure configuration has required fields
+        if 'url' not in section:
+            raise ValueError(f'S1 configuration invalid, ensure "url" is specified')
+
+        if 'site_id' not in section and 'account_id' not in section:
+            raise ValueError(f'S1 configuration invalid, specify a site_id or account_id')
+
+        # extract required information from configuration
+        if 'token' in section:
+            self._token = section['token']
+        else:
+            if 'S1_TOKEN' not in os.environ:
+                raise ValueError(f'S1 configuration invalid, specify "token" configuration value or "S1_TOKEN" '
+                                 f'environment variable')
+            self._token = os.environ['S1_TOKEN']
+
+        self._site_id = section['site_id'] if 'site_id' in section else None
+        self._account_id = section['account_id'] if 'account_id' in section else None
+
+        self._url = section['url'].rstrip('/')
+
+        if not self._url.startswith('https://'):
+            raise ValueError(f'URL must start with "https://"')
+
+        # create a session and a pooled HTTPAdapter
+        self._session = requests.session()
+        self._session.mount('https://', HTTPAdapter(pool_connections=10, pool_maxsize=10, max_retries=3))
+
+        # test API key by retrieving the sensor count, which is a fast operation
+        data = self._session.get(self._build_url('/web/api/v2.1/agents/count'),
+                                 headers=self._get_default_header(),
+                                 params=self._get_default_body()).json()
+
+        if 'errors' in data:
+            if data['code'] == 4010010:
+                raise ValueError(f'Failed to authenticate to SentinelOne: {data}')
+            else:
+                raise ValueError(f'Error when authenticating to SentinelOne: {data}')
+
+    def _build_url(self, stem: str):
+        """
+        Assemble URL for SentinelOne API query using base URI and URI stem.
+        """
+        if not stem.startswith('/'):
+            stem = '/' + stem
+
+        return self._url + stem
+
+    def _get_default_body(self) -> dict:
+        """
+        Get the default request body for a SentinelOne API query.
+        """
+        return {"siteIds": [self._site_id]} if self._site_id else {"accountIds": [self._account_id]}
+
+    def _get_default_header(self):
+        """
+        Get the default header for a SentinelOne API query.
+        """
+        return {"Authorization": f"ApiToken {self._token}", "Content-Type": "application/json"}
+
+    def build_query(self, filters: dict) -> Tuple[str, datetime, datetime]:
+        to_date = datetime.utcnow()
+        from_date = to_date - timedelta(days=14)
+        
+        query_base = ''
+
+        for key, value in filters.items():
+            if key == 'days':
+                from_date = to_date - timedelta(days=value)
+            elif key == 'minutes':
+                from_date = to_date - timedelta(minutes=value)
+            elif key == 'hostname':
+                if query_base:
+                    query_base += ' AND '
+
+                query_base += f' EndpointName containscis "{value}"'
+            elif key == 'username':
+                if query_base:
+                    query_base += ' AND '
+
+                query_base += f' UserName containscis "{value}"'
+            else:
+                self._echo(f'Query filter {key} is not supported by product {self.product}', logging.WARNING)
+
+        # S1 requires the date range to be supplied in the query request, not the query text
+        # therefore we return the from/to dates separately
+        return query_base, from_date, to_date
+
+    def _get_all_paginated_data(self, response: requests.Response, params: Optional[dict] = None,
+                                key='data') -> list[dict]:
+        """
+        Get and return all paginated data from the response, making additional queries if necessary.
+        """
+        response.raise_for_status()
+
+        data = list[dict]()
+        data.extend(response.json()[key])
+
+        pagination_info = response.json()['pagination']
+        while pagination_info['nextCursor']:
+            response = self._session.get(pagination_info['nextCursor'],
+                                         params=params, headers=self._get_default_header())
+            response.raise_for_status()
+            data.extend(response.json()[key])
+            pagination_info = response.json()['pagination']
+
+        return data
+
+    def _get_dv_events(self, query_id: str) -> list[dict]:
+        """
+        Retrieve events associated with a SentinelOne Deep Visibility query ID.
+        """
+        params = {
+            'queryId': query_id,
+            'limit': 1000,
+        }
+
+        while True:
+            query_status_response = self._session.get(self._build_url('/web/api/v2.1/dv/query-status'),
+                                                      params={'queryId': query_id}, headers=self._get_default_header())
+            query_status_response.raise_for_status()
+            data = query_status_response.json()['data']
+
+            self.log.debug(str(data))
+
+            if data['progressStatus'] == 100 or data['responseState'] == 'FAILED':
+                if data['responseState'] == 'FAILED':
+                    raise ValueError(f'S1QL query failed with message "{data["responseError"]}"')
+
+                response = self._session.get(self._build_url('/web/api/v2.1/dv/events'),
+                                             params=params, headers=self._get_default_header())
+
+                return self._get_all_paginated_data(response)
+            else:
+                time.sleep(10)
+
+    def process_search(self, tag: Union[str, Tuple], base_query: dict, query: str) -> None:
+        build_query, from_date, to_date = self.build_query(base_query)
+        query = query + build_query
+        self._echo(f'Built Query: {query}')
+
+        if tag not in self._queries:
+            self._queries[tag] = list()
+
+        self._queries[tag].append((from_date, to_date, query))
+
+    def nested_process_search(self, tag: Union[str, Tuple], criteria: dict, base_query: dict):
+        query_base, from_date, to_date = self.build_query(base_query)
+
+        try:
+            for search_field, terms in criteria.items():
+                all_terms = ', '.join(f'"{term}"' for term in terms)
+
+                if search_field == 'process_name':
+                    query = f"ProcessName in contains anycase ({all_terms})"
+                elif search_field == "ipaddr":
+                    query = f"IP in contains anycase ({all_terms})"
+                elif search_field == "cmdline":
+                    query = f"CmdLine in contains anycase ({all_terms})"
+                elif search_field == "digsig_publisher":
+                    query = f"SrcProcPublisher in contains anycase ({all_terms})"
+                elif search_field == "domain":
+                    query = f"Url in contains anycase ({all_terms})"
+                elif search_field == "internal_name":
+                    query = f"TgtFileInternalName in contains anycase ({all_terms})"
+                else:
+                    self._echo(f'Query filter {search_field} is not supported by product {self.product}',
+                               logging.WARNING)
+                    continue
+
+                if tag not in self._queries:
+                    self._queries[tag] = list()
+
+                self._queries[tag].append((from_date, to_date, query))
+        except KeyboardInterrupt:
+            self._echo("Caught CTRL-C. Returning what we have...")
+
+    def get_results(self) -> dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]:
+        self.log.debug('Entered get_results')
+
+        if len(self._queries) == 0:
+            return dict()
+
+        queries = set[Tuple[str, str]]()
+
+        min_from_date = datetime.utcnow()
+        to_date = min_from_date
+
+        for tag, values in self._queries.items():
+            for from_date, _, query in values:
+                if from_date < min_from_date:
+                    min_from_date = from_date
+
+                queries.add((tag, query))
+
+        queries = list(queries)
+
+        results = dict[Union[str, Tuple], list[Tuple[str, str, str, str]]]()
+        try:
+            # merge queries into one large query
+            first = True
+            for i in range(0, len(queries), 10):
+                # do not chain more than 10 ORs in a S1QL query
+
+                if first:
+                    first = False
+                else:
+                    # S1 has rate limit of 1 DB search per 60 seconds
+                    time.sleep(60)
+
+                merged_tags = set()
+                merged_query = ''
+                for tag, query in queries[i:i + 10]:
+                    if merged_query:
+                        merged_query += ' OR '
+
+                    merged_query += query
+                    merged_tags.add(tag)
+
+                merged_tag = (",".join((x[0] if isinstance(x, Tuple) else x for x in merged_tags)),
+                              ",".join((x[1] if isinstance(x, Tuple) else x for x in merged_tags)))
+
+                params = self._get_default_body()
+                params.update({
+                    "fromDate": _get_epoch_millis(min_from_date),
+                    "isVerbose": False,
+                    "queryType": ['events'],  # options: 'events', 'procesState'
+                    "limit": 20000,
+                    "toDate": _get_epoch_millis(to_date),
+                    "query": merged_query
+                })
+
+                self.log.debug(f'Query params: {params}')
+
+                query_response = self._session.post(self._build_url('/web/api/v2.1/dv/init-query'),
+                                                    headers=self._get_default_header(), data=json.dumps(params))
+
+                body = query_response.json()
+                if 'errors' in body and any(('could not parse query' in x['detail'] for x in body['errors'])):
+                    raise ValueError(f'S1 could not parse query "{merged_query}"')
+
+                self.log.debug(query_response.json())
+                query_response.raise_for_status()
+
+                query_id = body['data']['queryId']
+                self.log.info(f'Query ID is {query_id}')
+
+                results[merged_tag] = list()
+                for event in self._get_dv_events(query_id):
+                    hostname = event['endpointName']
+                    username = event['srcProcUser']
+                    path = event['processImagePath']
+                    command_line = event['srcProcCmdLine']
+                    results[merged_tag].append((hostname, username, path, command_line))
+        except KeyboardInterrupt:
+            self._echo("Caught CTRL-C. Returning what we have . . .")
+
+        return results

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -10,10 +10,7 @@ import requests
 from requests.adapters import HTTPAdapter
 
 from common import Product
-
-
-def _get_epoch_millis(date: datetime) -> int:
-    return int((date - datetime.utcfromtimestamp(0)).total_seconds() * 1000)
+from help import datetime_to_epoch_millis
 
 
 class SentinelOne(Product):
@@ -277,11 +274,11 @@ class SentinelOne(Product):
 
                 params = self._get_default_body()
                 params.update({
-                    "fromDate": _get_epoch_millis(min_from_date),
+                    "fromDate": datetime_to_epoch_millis(min_from_date),
                     "isVerbose": False,
                     "queryType": ['events'],  # options: 'events', 'procesState'
                     "limit": 20000,
-                    "toDate": _get_epoch_millis(to_date),
+                    "toDate": datetime_to_epoch_millis(to_date),
                     "query": merged_query
                 })
 

--- a/products/vmware_cb_enterprise_edr.py
+++ b/products/vmware_cb_enterprise_edr.py
@@ -23,7 +23,7 @@ def _convert_relative_time(relative_time):
 
 
 class CbEnterpriseEdr(Product):
-    product: str = 'cbth'
+    product: str = 'cbc'
     _conn: CbThreatHunterAPI  # CB Response API
 
     def __init__(self, profile: str, **kwargs):

--- a/products/vmware_cb_enterprise_edr.py
+++ b/products/vmware_cb_enterprise_edr.py
@@ -27,8 +27,8 @@ class CbEnterpriseEdr(Product):
     product: str = 'cbth'
     _conn: CbThreatHunterAPI  # CB Response API
 
-    def __init__(self, profile: str):
-        super().__init__(self.product, profile)
+    def __init__(self, profile: str, **kwargs):
+        super().__init__(self.product, profile, **kwargs)
 
     def _authenticate(self):
         if self.profile:

--- a/products/vmware_cb_response.py
+++ b/products/vmware_cb_response.py
@@ -26,8 +26,8 @@ class CbResponse(Product):
     product: str = 'cbr'
     _conn: CbEnterpriseResponseAPI  # CB Response API
 
-    def __init__(self, profile: str):
-        super().__init__(self.product, profile)
+    def __init__(self, profile: str, **kwargs):
+        super().__init__(self.product, profile, **kwargs)
 
     def _authenticate(self):
         if self.profile:

--- a/products/vmware_cb_response.py
+++ b/products/vmware_cb_response.py
@@ -62,7 +62,8 @@ class CbResponse(Product):
         try:
             # noinspection PyUnresolvedReferences
             for proc in self._conn.select(Process).where(query):
-                result = Result(proc.hostname.lower(), proc.username.lower(), proc.path, proc.cmdline)
+                result = Result(proc.hostname.lower(), proc.username.lower(), proc.path, proc.cmdline,
+                                (proc.start,))
                 results.add(result)
         except KeyboardInterrupt:
             self._echo("Caught CTRL-C. Returning what we have . . .")
@@ -76,10 +77,13 @@ class CbResponse(Product):
             for search_field, terms in criteria.items():
                 query = '(' + ' OR '.join('%s:%s' % (search_field, term) for term in terms) + ')'
                 query += self.build_query(base_query)
+                
+                self.log.debug(f'Query: {query}')
 
                 # noinspection PyUnresolvedReferences
                 for proc in self._conn.select(Process).where(query):
-                    result = Result(proc.hostname.lower(), proc.username.lower(), proc.path, proc.cmdline)
+                    result = Result(proc.hostname.lower(), proc.username.lower(), proc.path, proc.cmdline,
+                                    (proc.start,))
                     results.add(result)
         except Exception as e:
             self._echo(f'Error (see log for details): {e}', logging.ERROR)
@@ -89,3 +93,6 @@ class CbResponse(Product):
             self._echo("Caught CTRL-C. Returning what we have . . .")
 
         self._add_results(list(results), tag)
+
+    def get_other_row_headers(self) -> list[str]:
+        return ['Process Start']

--- a/products/vmware_cb_response.py
+++ b/products/vmware_cb_response.py
@@ -1,86 +1,95 @@
-import csv
-import json
-import os
-import time
-from datetime import datetime
-from pprint import pprint
+from datetime import datetime, timedelta
 
 import click
-import cbapi.errors
 from cbapi.response import CbEnterpriseResponseAPI
 from cbapi.response.models import Process
 
+from common import Product
 
-def convert_relative_time(self, relative_time):
-    """Convert a Cb Response relative time boundary (i.e., start:-1440m) to a
-    device_timestamp:
-      device_timestamp:[2019-06-02T00:00:00Z TO 2019-06-03T23:59:00Z]
+
+def _convert_relative_time(relative_time):
+    """
+    Convert a Cb Response relative time boundary (i.e., start:-1440m) to a device_timestamp:
+    device_timestamp:[2019-06-02T00:00:00Z TO 2019-06-03T23:59:00Z]
     """
     time_format = "%Y-%m-%dT%H:%M:%SZ"
     minus_minutes = relative_time.split(':')[1].split('m')[0].split('-')[1]
-    end_time = datetime.datetime.now()
-    start_time = end_time - datetime.timedelta(minutes=int(minus_minutes))
+    end_time = datetime.now()
+    start_time = end_time - timedelta(minutes=int(minus_minutes))
     device_timestamp = 'device_timestamp:[{0} TO {1}]'.format(start_time.strftime(time_format),
                                                               end_time.strftime(time_format))
     return device_timestamp
 
 
-def build_query(filters):
-    query_base = ''
+class CbResponse(Product):
+    product: str = 'cbr'
+    _conn: CbEnterpriseResponseAPI  # CB Response API
 
-    for key, value in filters.items():
-        if key == 'days':
-            query_base += ' start:-%dm' % (value * 1440)
+    def __init__(self, profile: str):
+        super().__init__(self.product, profile)
 
-        if key == 'minutes':
-            query_base += ' start:-%dm' % value
+    def _authenticate(self):
+        if self.profile:
+            cb_conn = CbEnterpriseResponseAPI(profile=self.profile)
+        else:
+            cb_conn = CbEnterpriseResponseAPI()
 
-        if key == 'hostname':
-            query_base += ' hostname:%s' % value
+        self._conn = cb_conn
 
-        if key == 'username':
-            query_base += ' username:%s' % value
+    def build_query(self, filters: dict):
+        query_base = ''
 
-    return query_base
+        for key, value in filters.items():
+            if key == 'days':
+                query_base += ' start:-%dm' % (value * 1440)
 
+            if key == 'minutes':
+                query_base += ' start:-%dm' % value
 
-def process_search(cb_conn, base, user_query):
+            if key == 'hostname':
+                query_base += ' hostname:%s' % value
 
-    results = set()
+            if key == 'username':
+                query_base += ' username:%s' % value
 
-    query = user_query + build_query(base)
-    click.echo(query)
+        return query_base
 
-    try:
-        for proc in cb_conn.select(Process).where(query):
-            results.add((proc.hostname.lower(),
-                         proc.username.lower(),
-                         proc.path,
-                         proc.cmdline))
-    except KeyboardInterrupt:
-        click.echo("Caught CTRL-C. Returning what we have . . .")
+    def process_search(self, base_query, query):
+        results = set()
 
-    return results
+        query = query + self.build_query(base_query)
+        click.echo(query)
 
-
-def nested_process_search(cb_conn, criteria, base):
-    results = set()
-
-    try:
-        for search_field, terms in criteria.items():
-            query = '(' + ' OR '.join('%s:%s' % (search_field, term) for term in terms) + ')'
-            query += build_query(base)
-
-            for proc in cb_conn.select(Process).where(query):
+        try:
+            # noinspection PyUnresolvedReferences
+            for proc in self._conn.select(Process).where(query):
                 results.add((proc.hostname.lower(),
                              proc.username.lower(),
                              proc.path,
                              proc.cmdline))
-    except Exception as e:
-        click.echo(e)
-        pass
-    except KeyboardInterrupt:
-        click.echo("Caught CTRL-C. Returning what we have . . .")
+        except KeyboardInterrupt:
+            click.echo("Caught CTRL-C. Returning what we have . . .")
 
-    return results
+        return results
 
+    def nested_process_search(self, criteria, base_query):
+        results = set()
+
+        try:
+            for search_field, terms in criteria.items():
+                query = '(' + ' OR '.join('%s:%s' % (search_field, term) for term in terms) + ')'
+                query += self.build_query(base_query)
+
+                # noinspection PyUnresolvedReferences
+                for proc in self._conn.select(Process).where(query):
+                    results.add((proc.hostname.lower(),
+                                 proc.username.lower(),
+                                 proc.path,
+                                 proc.cmdline))
+        except Exception as e:
+            click.echo(e)
+            pass
+        except KeyboardInterrupt:
+            click.echo("Caught CTRL-C. Returning what we have . . .")
+
+        return results

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click~=8.0.4
 cbapi~=1.7.0
 requests~=2.27.1
 setuptools~=60.6.0
+tqdm~=4.63.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+click~=8.0.4
+cbapi~=1.7.0
+requests~=2.27.1
+setuptools~=60.6.0

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
         'Programming Language :: Python',
         ],
     install_requires=[
-        'cbapi==1.7.0', 'click', 'requests', 'typing'
+        'cbapi==1.7.0', 'click', 'requests', 'typing', 'tqdm'
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
         'Programming Language :: Python',
         ],
     install_requires=[
-        'cbapi==1.7.0', 'click', 'requests', 'typing', 'tqdm'
+        'cbapi==1.7.0', 'click', 'requests', 'tqdm'
         ]
     )

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
         'Programming Language :: Python',
         ],
     install_requires=[
-        'cbapi==1.7.0', 'click'
+        'cbapi==1.7.0', 'click', 'requests', 'typing'
         ]
     )

--- a/surveyor.py
+++ b/surveyor.py
@@ -131,14 +131,16 @@ def cli(ctx, prefix: Optional[str], hostname: Optional[str], profile: str, days:
 # S1 options
 @cli.command('s1', help="Query SentinelOne")
 @click.option("--site-id", help="ID of SentinelOne site to query", multiple=True, default=None)
-@click.option("--account-id", help="ID of SentinelOne site to query", multiple=True, default=None)
+@click.option("--account-id", help="ID of SentinelOne account to query", multiple=True, default=None)
+@click.option("--account-name", help="Name of SentinelOne account to query", multiple=True, default=None)
 @click.option("--creds", 'creds', help="Path to credential file", type=click.Path(exists=True), required=True)
 @click.pass_context
-def s1(ctx, site_id: Optional[Tuple], account_id: Optional[Tuple], creds: Optional[str]):
+def s1(ctx, site_id: Optional[Tuple], account_id: Optional[Tuple], account_name: Optional[Tuple], creds: Optional[str]):
     ctx.obj.product_args = {
         'creds_file': creds,
         'site_id': list(site_id),
-        'account_id': list(account_id)
+        'account_id': list(account_id),
+        'account_name': list(account_name)
     }
 
     survey(ctx, 's1')

--- a/surveyor.py
+++ b/surveyor.py
@@ -35,7 +35,7 @@ table_template: Tuple[int, int, int, int, int, int] = (30, 30, 30, 30, 30, 30)
 
 
 def _write_results(output: Optional[csv.writer], results: list[Tuple[str, str, str, str]], program: str, source: str,
-                   tag: Union[str, Tuple], log: logging.Logger):
+                   tag: Union[str, Tuple], log: logging.Logger, use_tqdm: bool = False):
     """
     Helper function for writing search results to CSV or STDOUT.
     """
@@ -44,9 +44,9 @@ def _write_results(output: Optional[csv.writer], results: list[Tuple[str, str, s
             tag = tag[0]
 
         if len(results) > 0:
-            log_echo(f"\033[92m-->{tag}: {len(results)} results \033[0m", log)
+            log_echo(f"\033[92m-->{tag}: {len(results)} results \033[0m", log, use_tqdm=use_tqdm)
         else:
-            log_echo(f"-->{tag}: {len(results)} results", log)
+            log_echo(f"-->{tag}: {len(results)} results", log, use_tqdm=use_tqdm)
 
     write_results(output, results, program, source, template=table_template)
     
@@ -257,8 +257,9 @@ def cli(ctx, prefix: Optional[str], hostname: Optional[str], profile: str, days:
 
                         if product.has_results():
                             # write results as they become available
-                            for _, nested_results in product.get_results().items():
-                                _write_results(writer, nested_results, program, source, program, log)
+                            for (c_program, c_source), nested_results in product.get_results(final_call=False).items():
+                                _write_results(writer, nested_results, program, c_source, c_program, log,
+                                               use_tqdm=True)
 
                             # ensure results are only written once
                             product.clear_results()

--- a/surveyor.py
+++ b/surveyor.py
@@ -1,10 +1,16 @@
+import sys
+
+# ensure Python version is compatible
+if not sys.version_info.major == 3 or sys.version_info.minor < 9:
+    print(f'Python 3.9+ is required to run Surveyor (current: {sys.version_info.major}.{sys.version_info.minor})')
+    exit(1)
+
 import csv
 import dataclasses
 import datetime
 import json
 import logging
 import os
-import sys
 from typing import Optional, Tuple, Callable
 
 import click
@@ -13,13 +19,6 @@ from tqdm import tqdm
 from common import Tag, Result
 from help import log_echo
 from load import get_product_instance, get_products
-
-
-# ensure Python version is compatible
-if not sys.version_info.major == 3 and sys.version_info.minor >= 9:
-    print('Python 3.9 or higher is required to run Surveyor.')
-    print(f'You are using Python v{sys.version_info.major}.{sys.version_info.minor}')
-    exit(1)
 
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help", "-what-am-i-doing"])

--- a/surveyor.py
+++ b/surveyor.py
@@ -290,8 +290,8 @@ def cli(ctx, prefix: Optional[str], hostname: Optional[str], profile: str, days:
                             product.clear_results()
 
             # write any remaining results
-            for (program, source), nested_results in product.get_results().items():
-                _write_results(writer, nested_results, program, source, program, log)
+            for tag, nested_results in product.get_results().items():
+                _write_results(writer, nested_results, tag.tag, tag.data, tag, log)
 
         if output_file:
             log_echo(f"\033[95mResults saved: {output_file.name}\033[0m", log)

--- a/surveyor.py
+++ b/surveyor.py
@@ -193,6 +193,9 @@ def survey(ctx, product: str = 'cbr'):
     if (opt.output or opt.prefix) and opt.no_file:
         ctx.fail('--output and --prefix cannot be used with --no-file')
 
+    if opt.days and opt.minutes:
+        ctx.fail('--days and --minutes are mutually exclusive')
+
     # instantiate a logger
     log = logging.getLogger('surveyor')
     logging.debug(f'Product: {product}')

--- a/surveyor.py
+++ b/surveyor.py
@@ -4,6 +4,7 @@ import datetime
 import json
 import logging
 import os
+import sys
 from typing import Optional, Tuple, Callable
 
 import click
@@ -12,6 +13,14 @@ from tqdm import tqdm
 from common import Tag, Result
 from help import log_echo
 from load import get_product_instance, get_products
+
+
+# ensure Python version is compatible
+if not sys.version_info.major == 3 and sys.version_info.minor >= 9:
+    print('Python 3.9 or higher is required to run Surveyor.')
+    print(f'You are using Python v{sys.version_info.major}.{sys.version_info.minor}')
+    exit(1)
+
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help", "-what-am-i-doing"])
 

--- a/surveyor.py
+++ b/surveyor.py
@@ -48,9 +48,9 @@ def _write_results(output: Optional[csv.writer], results: list[Result], program:
             tag = tag[0]
 
         if len(results) > 0:
-            log_echo(f"\033[92m-->{tag}: {len(results)} results \033[0m", log, use_tqdm=use_tqdm)
+            log_echo(f"\033[92m-->{tag.tag}: {len(results)} results \033[0m", log, use_tqdm=use_tqdm)
         else:
-            log_echo(f"-->{tag}: {len(results)} results", log, use_tqdm=use_tqdm)
+            log_echo(f"-->{tag.tag}: {len(results)} results", log, use_tqdm=use_tqdm)
 
     for result in results:
         row = [result.hostname, result.username, result.path, result.command_line, program, source]
@@ -58,7 +58,7 @@ def _write_results(output: Optional[csv.writer], results: list[Result], program:
         if output:
             if result.other_data:
                 row.extend(result.other_data)
-                
+
             output.writerow(row)
         else:
             # trim data to make sure it fits into table format

--- a/surveyor.py
+++ b/surveyor.py
@@ -1,29 +1,74 @@
 import csv
 import json
+import logging
 import os
-from pprint import pprint
+import re
+from typing import Tuple
 
-import click 
+import click
 from click import ClickException
 
-from common import EDRCommon
+from common import Product
+from load import get_product_instance, get_products
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help", "-what-am-i-doing"])
+
 # Application version
 current_version = "1.0"
 
+# regular expression that detects ANSI color codes
+ansi_escape_regex = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', re.VERBOSE)
 
-@click.group("surveyor", context_settings=CONTEXT_SETTINGS, invoke_without_command=True,
-             chain=False)
-# @click.command("surveyor",context_settings=CONTEXT_SETTINGS)
+
+def _list_products(ctx, _, value):
+    """
+    Print all implemented products to STDOUT.
+    """
+    if not value or ctx.resilient_parsing:
+        return
+
+    for product in get_products():
+        click.echo(product)
+    ctx.exit()
+
+
+def _strip_ansi_codes(message: str) -> str:
+    """
+    Strip ANSI sequences from a log string
+    """
+    return ansi_escape_regex.sub('', message)
+
+
+def _log_echo(message: str, log: logging.Logger):
+    """
+    Write a command to STDOUT and the debug log stream.
+    """
+    click.echo(message)
+
+    # strip ANSI sequences from log string
+    log.debug(_strip_ansi_codes(message))
+
+
+def _write_csv(output: csv.writer, results: list[Tuple[str, str, str, str]], program: str, source: str):
+    """
+    Write results to output CSV.
+    """
+    for hostname, username, path, command_line in results:
+        row = [hostname, username, path, command_line, program, source]
+        output.writerow(row)
+
+
+# noinspection SpellCheckingInspection
+@click.group("surveyor", context_settings=CONTEXT_SETTINGS, invoke_without_command=True, chain=False)
 # list of all the different products we support
 @click.option("--threathunter", 'product', help="Use this to use Cb ThreatHunter.", flag_value="cbth", default=False)
 @click.option("--response", 'product', help="Use this to use Cb Response.", flag_value="cbr", default=True)
-@click.option("--defender", 'product', help="Use this to query Microsoft Defender for Endpoints", flag_value="defender", default=False)
-@click.option("--atp", 'product', help="Use this to query Microsoft Defender for Endpoints", flag_value="defender", default=False)
-
-@click.option("--creds", 'creds', help="Use this to define the path of the ini file with your ATP credentials", type=click.Path(exists=True))
-
+@click.option("--defender", 'product', help="Use this to query Microsoft Defender for Endpoints", flag_value="defender",
+              default=False)
+@click.option("--atp", 'product', help="Use this to query Microsoft Defender for Endpoints", flag_value="defender",
+              default=False)
+@click.option("--creds", 'creds', help="Use this to define the path of the ini file with your ATP credentials",
+              type=click.Path(exists=True))
 # filtering options
 @click.option("--prefix", help="Output filename prefix.", type=click.STRING)
 @click.option("--profile", help="The credentials profile to use.", type=click.STRING)
@@ -38,113 +83,136 @@ current_version = "1.0"
 @click.option("--iocfile", help="IOC file to process. One IOC per line. REQUIRES --ioctype")
 @click.option("--ioctype", help="One of: ipaddr, domain, md5")
 # optional output
-@click.option("--output", "--o",
-              help="Specify the output file for the results. The default is create survey.csv in the current directory.")
+@click.option("--output", "--o", help="Specify the output file for the results. "
+                                      "The default is create survey.csv in the current directory.")
 @click.version_option(current_version)
+@click.option('--products', default=False, is_flag=True, callback=_list_products, expose_value=False, is_eager=True)
 @click.pass_context
 def cli(ctx, prefix, hostname, profile, days, minutes, product, username, iocfile, ioctype, query, output, defdir,
         deffile, creds):
+    # instantiate a logger
+    log = logging.getLogger('surveyor')
+    logging.debug(f'Product: {product}')
 
-    if product == "defender" and creds is None: 
-        raise ClickException("\033[91m --atpcreds with the path of the INI file is required")
-    # creates utility object with the profile and product to pass
-    # sub functions to the correct product
-    utils = EDRCommon(product, profile)
+    # perform checks to ensure required parameters are present
+    if product == "defender" and creds is None:
+        # defender product requires credential file
+        raise ClickException("\033[91m--creds required when using 'defender' platform\033[0m")
 
-    # placeholder for definition files if --defdir or --deffile
-    # is selected
-    definition_files = []
+    # build arguments required for product class
+    # must products only require the profile name
+    kwargs = {
+        'profile': profile
+    }
 
-    # this will build out or store the filter query based on the parameters
-    # somehow needs to be modular and easy to add to and account for
-    # different ways to do this via the different products`
-    base_query = {}
+    # add any custom required properties to kwargs
+    if creds:
+        kwargs['creds_file'] = creds
+
+    # instantiate a product class instance based on the product string
+    try:
+        product: Product = get_product_instance(product, **kwargs)
+    except ValueError as e:
+        log.exception(e)
+        click.echo(str(e))
+        ctx.exit()
+
+    # placeholder for definition files if --defdir or --deffile is selected
+    definition_files = list()
+
+    # base_query stores the filters applied to the product query
+    # initial query is retrieved from product instance
+    base_query = product.base_query()
+
+    # add filters specified by user
     if username is not None:
         base_query.update({"username": username})
+
     if hostname is not None:
         base_query.update({"hostname": hostname})
+
     if days is not None:
         base_query.update({"days": days})
+
     if minutes is not None:
         base_query.update({"minutes": minutes})
 
-    # create a single connection to the appropriate product
-    # for use in our calls
-    if product == "defender":
-        conn = utils.get_connection_creds(creds)
-    else: 
-        conn = utils.get_connection()
-
-    # set the output file
+    # determine output file name
     if output:
-        output_file = open(output, 'w', newline='')
+        file_name = output
     elif prefix:
-        output_file = open(f'{prefix}-survey.csv', 'w', newline='')
+        file_name = f'{prefix}-survey.csv'
     else:
-        output_file = open('survey.csv', 'w', newline='')
+        file_name = 'survey.csv'
 
-    # write the header row
-    writer = csv.writer(output_file)
-    writer.writerow(["endpoint", "username", "process_path", "cmdline", "program", "source"])
+    with open(file_name, 'w', newline='') as output_file:
+        # care CSV writer and write the header row
+        writer = csv.writer(output_file)
+        writer.writerow(["endpoint", "username", "process_path", "cmdline", "program", "source"])
 
-    #if --query run the query and write results to the csv
-    if query:
-        click.echo(f"Running Query: {query}")
-        results = utils.process_search(conn, query, base_query)
-        utils.write_csv(writer, results, query, "query")
+        # if --query run the query and write results to the csv
+        if query:
+            _log_echo(f"Running Query: {query}", log)
+            results = product.process_search(query, base_query)
 
-    # if --deffile add file to list
-    elif deffile:
-        if not os.path.exists(deffile):
-            ctx.fail("The deffile doesn't exist. Please try again.")
-        definition_files.append(deffile)
+            _write_csv(writer, results, query, "query")
 
-    # if --defdir add all files to list
-    elif defdir:
-        if not os.path.exists(defdir):
-            ctx.fail("The defdir doesn't exist. Please try again.")
-        else:
-            for root, dirs, files in os.walk(defdir):
-                for filename in files:
-                    if os.path.splitext(filename)[1] == '.json':
-                        # if filename.endswith('.json'):
-                        definition_files.append(os.path.join(root, filename))
+        # if --deffile add file to list
+        elif deffile:
+            if not os.path.exists(deffile):
+                ctx.fail("The deffile doesn't exist. Please try again.")
+            definition_files.append(deffile)
 
-    # if --iocfile run search for iocs
-    elif iocfile:
-        if ioctype is None:
-            ctx.fail("[!] --iocfile requires --ioctype")
-        else:
-            with open(iocfile) as iocfile:
-                data = iocfile.readlines()
-                click.echo(f"Processing IOC file: {iocfile}")
-                for ioc in data:
-                    ioc = ioc.strip()
-                    query = f"{ioctype}:{ioc}"
-                    results = utils.process_search(conn, query, base_query)
-                    click.echo(f"-->{ioc}")
-                    utils.write_csv(writer, results, ioc, 'ioc')
+        # if --defdir add all files to list
+        elif defdir:
+            if not os.path.exists(defdir):
+                ctx.fail("The defdir doesn't exist. Please try again.")
+            else:
+                for root, dirs, files in os.walk(defdir):
+                    for filename in files:
+                        if os.path.splitext(filename)[1] == '.json':
+                            # if filename.endswith('.json'):
+                            definition_files.append(os.path.join(root, filename))
 
-    # run search against definition files and write to csv
-    if deffile is not None or defdir is not None:
-        results_set = set()
-        for definitions in definition_files:
-            click.echo(f"\033[96m Processing definition file for {definitions} \033[0m")
-            basename = os.path.basename(definitions)
-            source = os.path.splitext(basename)[0]
+        # if --iocfile run search for iocs
+        elif iocfile:
+            if ioctype is None:
+                ctx.fail("[!] --iocfile requires --ioctype")
+            else:
+                with open(iocfile) as iocfile:
+                    data = iocfile.readlines()
+                    _log_echo(f"Processing IOC file: {iocfile}", log)
 
-            with open(definitions, 'r') as file:
-                programs = json.load(file)
-                for program, criteria in programs.items():
-                    nested_results = utils.nested_process_search(criteria, conn, base_query)
-                    if len(nested_results) > 0:
-                        click.echo(f"\033[92m -->{program}: {len(nested_results)} results \033[0m")    
-                    else:                     
-                        click.echo(f"-->{program}: {len(nested_results)} results")
-                    utils.write_csv(writer, nested_results, program, source)
-                    results_set |= nested_results
-    output_file.close()
-    click.echo(f"\033[95m Results saved: {output_file.name} \033[0m")
+                    for ioc in data:
+                        ioc = ioc.strip()
+                        query = f"{ioctype}:{ioc}"
+                        results = product.process_search(query, base_query)
+                        _log_echo(f"-->{ioc}", log)
+                        _write_csv(writer, results, ioc, 'ioc')
+
+        # run search against definition files and write to csv
+        if deffile is not None or defdir is not None:
+            results_set = set()
+            for definitions in definition_files:
+                _log_echo(f"\033[96m Processing definition file for {definitions} \033[0m", log)
+
+                basename = os.path.basename(definitions)
+                source = os.path.splitext(basename)[0]
+
+                with open(definitions, 'r') as file:
+                    programs = json.load(file)
+                    for program, criteria in programs.items():
+                        nested_results = product.nested_process_search(criteria, base_query)
+
+                        if len(nested_results) > 0:
+                            _log_echo(f"\033[92m-->{program}: {len(nested_results)} results \033[0m", log)
+                        else:
+                            _log_echo(f"-->{program}: {len(nested_results)} results", log)
+
+                        _write_csv(writer, nested_results, program, source)
+                        results_set |= nested_results
+
+        _log_echo(f"\033[95mResults saved: {output_file.name}\033[0m", log)
 
 
 if __name__ == "__main__":

--- a/surveyor.py
+++ b/surveyor.py
@@ -145,6 +145,8 @@ def cli(ctx, prefix: Optional[str], hostname: Optional[str], profile: str, days:
     if creds:
         kwargs['creds_file'] = creds
 
+    kwargs['tqdm_echo'] = not no_progress
+
     # instantiate a product class instance based on the product string
     try:
         product = get_product_instance(product, **kwargs)

--- a/surveyor.py
+++ b/surveyor.py
@@ -255,6 +255,15 @@ def cli(ctx, prefix: Optional[str], hostname: Optional[str], profile: str, days:
                     for program, criteria in programs.items():
                         product.nested_process_search((program, source), criteria, base_query)
 
+                        if product.has_results():
+                            # write results as they become available
+                            for _, nested_results in product.get_results().items():
+                                _write_results(writer, nested_results, program, source, program, log)
+
+                            # ensure results are only written once
+                            product.clear_results()
+
+            # write any remaining results
             for (program, source), nested_results in product.get_results().items():
                 _write_results(writer, nested_results, program, source, program, log)
 

--- a/surveyor.py
+++ b/surveyor.py
@@ -146,38 +146,30 @@ def s1(ctx, site_id: Optional[Tuple], account_id: Optional[Tuple], account_name:
     survey(ctx, 's1')
 
 
-@cli.command('threathunter', help="Query Cb ThreatHunter")
+@cli.command('cbc', help="Query VMware Cb Enterprise EDR")
 @click.pass_context
 def cbth(ctx):
-    survey(ctx, 'cbth')
+    survey(ctx, 'cbc')
 
 
-@cli.command('cbr', help="Query Cb Response")
+@cli.command('cbr', help="Query VMware Cb Response")
 @click.pass_context
 def cbr(ctx):
     survey(ctx, 'cbr')
 
 
-@cli.command('response', help="Query Cb Response")
+@cli.command('cbr', help="Query Cb Response")
 @click.pass_context
 def response_alternate(ctx):
     survey(ctx, 'cbr')
 
 
-@cli.command('defender', help="Query Microsoft Defender for Endpoints")
+@cli.command('dfe', help="Query Microsoft Defender for Endpoints")
 @click.option("--creds", 'creds', help="Path to credential file", type=click.Path(exists=True))
 @click.pass_context
-def defender(ctx, creds: Optional[str]):
+def dfe(ctx, creds: Optional[str]):
     ctx.obj.product_args = {'creds_file': creds}
-    survey(ctx, 'defender')
-
-
-@cli.command('atp', help="Query Microsoft Defender for Endpoints")
-@click.option("--creds", 'creds', help="Path to credential file", type=click.Path(exists=True), required=True)
-@click.pass_context
-def defender_alternate(ctx, creds: Optional[str]):
-    ctx.obj.product_args = {'creds_file': creds}
-    survey(ctx, 'defender')
+    survey(ctx, 'dfe')
 
 
 def survey(ctx, product: str = 'cbr'):

--- a/surveyor.py
+++ b/surveyor.py
@@ -1,7 +1,7 @@
 import sys
 
-# ensure Python version is compatible
-if not sys.version_info.major == 3 or sys.version_info.minor < 9:
+# ensure Python version is compatible (Python v2 will always error out)
+if sys.version_info.major == 3 and sys.version_info.minor < 9:
     print(f'Python 3.9+ is required to run Surveyor (current: {sys.version_info.major}.{sys.version_info.minor})')
     exit(1)
 


### PR DESCRIPTION
This is a fairly major rewrite of the surveyor tool. My initial goal was to implement SentinelOne support but I realized that doing so would be very difficult given the project's architecture. The problems were as follows:
- Implementing a new product required adding checks to various methods in `common.py` as well as changes to `surveyor.py`.
- Authentication for each product was handled in `common.py` instead of being delegated to each individual product.
- `process_search` and `nested_process_search` both required results to be returned to `surveyor.py`. This does not work well for SentinelOne due to the 1 request per minute rate limit for Deep Visibility searches via the API. The correct way to handle this is to combine various process searches into a single query, but this was not possible given the old architecture.

I addressed these issues in the following ways:

#### 1. Refactor for CBR/CBTH/Defender products:
- Refactored `common.py` into an abstract class that defines a product interface.
- Refactored all supported products to inherit from the new abstract base class.
- Refactored surveyor.py to take advantage of the new interface.
- Implemented `load.py` which can dynamically load any product class based on its unique name.

The benefits of this refactor are as follows:
- Authentication logic for each product is now encapsulated in the product itself. Before, authentication had to be handled in `surveyor.py` with branching paths depending on how the authentication for the particular product functioned (profile vs credential file).
- Implementing a new product is now as simple as creating a new class in `products/` and making sure it has a unique `product` attribute. `load.py` will automatically expose the new product to `surveyor.py`.

#### 2. Refactored `process_search` and `nested_process_search`:
- Both methods no longer return any data. Instead, the results are stored in a class attribute and can be retrieved via `product.get_results()`. This returns a dictionary where the keys represent `tags` used to identify the results and the values represent the results themselves.
- This change maintains the ability for `surveyor.py` to display per-process/query result totals while also granting new products greater flexibility to change the way they handle search operations internally.

#### 3. Miscellaneous changes made:
- Simplified the code flow for certain operations in `surveyor.py` (e.g. having three branched `open()` calls when the only change between them was the file name).
- Enabled multiple search flags to be used in tandem (e.g. you can specify both `--query` and `--deffile`).
- Implemented logging via python's `logging` module.
- Logs are written to the `logs` folder. This can be configured via the CLI parameter `--log-dir`.
- Added type hints. Note that this does reduce the versions of Python the project is compatible with. The benefit is that it becomes easier to ensure errors are not introduced during development.
- Refactored code to comply with PEP8.
- Minor changes to improve documentation, logging, and error handling.
- Deffiles that reside in the `definitions` folder can now be resolved by the `--deffiles` CLI option without needing to specify the `definitions` folder or the `.json` extension.
- Created a `requirements.txt` file to list required dependencies for development environments.

### Resolved issues:
- Closes #31: Implemented progress bar for `deffiles` parsing and added `--no-progress` CLI option to suppress the progress bar.
- Closes #2: Added `--no-file` CLI option to print results to STDOUT instead of a CSV file. Implicitly sets `--no-progress` to `True`.
- Closes #52: Implemented `SentinelOne` product.

### Implemented support for `SentinelOne`:
- SentinelOne support is implemented using the SentinelOne API and Deep Visibility.
- Searches are combined to reduce the number of API requests made to SentinelOne.
- The 1 request per minute rate limit for Deep Visibility queries is observed.
- Added `s1` click command.

### Potential Breaking Changes:
- Click was modified to leverage commands. This means that existing CLI strings will no longer function as the product no longer needs to be prepended with `--`.
- Verified that the changes have not impacted the `cbr` product implementation's survey results.
- I do not have access to `cbth` or `defender` product instances so those have not been tested.

### New module dependencies:
- Added `requests` to the list of required module installs in `setup.py`. Note that this module was already required for the `defender` product.
- `tqdm` to resolve issue #31.

### To-Do:
- ~~These changes need to be tested on all implemented products.~~
- Documentation needs to be updated.
- There are likely some common CBR search terms that have not been mapped to their S1 equivalents.
- ~~S1 query merging logic can be improved.~~
- ~~Add timestamp to output for all products.~~