### PR TITLE
Implement CBC SDK

### DIFF
--- a/load.py
+++ b/load.py
@@ -16,7 +16,7 @@ for module in os.listdir(os.path.join(os.path.dirname(__file__), 'products')):
 
     # cbapi module has broken imports for Python 3.10+
     # importing it here would result in none of the products working on Python 3.10+
-    if sub_module == 'vmware_cb_response' or sub_module == 'vmware_cb_enterprise_edr':
+    if sub_module == 'vmware_cb_response':
         continue
 
     __import__('products.' + sub_module, locals(), globals())
@@ -50,15 +50,6 @@ def get_product_instance(product: str, **kwargs) -> Product:
         from products.vmware_cb_response import CbResponse
         return CbResponse(**kwargs)
 
-    if product == 'cbc':
-        if sys.version_info.major == 3 and sys.version_info.minor > 9:
-            click.secho(f'cbc only functions on Python 3.9 due to a library limitation '
-                        f'(this will be resolved in a future update)', fg='red')
-            exit(1)
-
-        from products.vmware_cb_enterprise_edr import CbEnterpriseEdr
-        return CbEnterpriseEdr(**kwargs)
-
     for subclass in _get_subclasses():
         if subclass.product == product:
             return subclass(**kwargs)
@@ -70,4 +61,4 @@ def get_products() -> Iterable[str]:
     """
     Get a list of all implemented product strings.
     """
-    return [subclass.product for subclass in _get_subclasses()] + ['cbr', 'cbc']
+    return [subclass.product for subclass in _get_subclasses()] + ['cbr']

--- a/products/vmware_cb_enterprise_edr.py
+++ b/products/vmware_cb_enterprise_edr.py
@@ -1,9 +1,10 @@
 import datetime
 import logging
 
-import cbapi.errors
-from cbapi.psc.threathunter import CbThreatHunterAPI, Process
-from cbapi.psc.threathunter import QueryBuilder
+import cbc_sdk.errors
+from cbc_sdk.rest_api import CBCloudAPI
+from cbc_sdk.platform import Process
+from cbc_sdk.base import QueryBuilder
 
 from common import Product, Result, Tag
 
@@ -24,16 +25,16 @@ def _convert_relative_time(relative_time):
 
 class CbEnterpriseEdr(Product):
     product: str = 'cbc'
-    _conn: CbThreatHunterAPI  # CB Response API
+    _conn: CBCloudAPI  # CB Cloud API
 
     def __init__(self, profile: str, **kwargs):
         super().__init__(self.product, profile, **kwargs)
 
     def _authenticate(self):
         if self.profile:
-            cb_conn = CbThreatHunterAPI(profile=self.profile)
+            cb_conn = CBCloudAPI(profile=self.profile)
         else:
-            cb_conn = CbThreatHunterAPI()
+            cb_conn = CBCloudAPI()
 
         self._conn = cb_conn
 
@@ -113,7 +114,7 @@ class CbEnterpriseEdr(Product):
                     result = Result(proc.device_name, proc.process_username[0], proc.process_name,
                                     proc.process_cmdline[0], (proc.device_timestamp,))
                     results.add(result)
-            except cbapi.errors.ApiError as e:
+            except cbc_sdk.errors.ApiError as e:
                 self._echo(f'Cb API Error (see log for details): {e}', logging.ERROR)
                 self.log.exception(e)
             except KeyboardInterrupt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cbapi~=1.7.0
 requests~=2.27.1
 setuptools~=60.6.0
 tqdm~=4.63.0
+carbon-black-cloud-sdk~=1.3.6

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,15 @@ def find_scripts():
 
 
 setup(
-    name='cb-response-surveyor',
+    name='surveyor',
     author='Keith McCammon',
     author_email='keith@redcanary.com',
-    url='https://github.com/redcanaryco/cb-response-surveyor',
+    url='https://github.com/redcanaryco/surveyor',
     license='MIT',
     packages=find_packages(),
     scripts=find_scripts(),
-    description='Extracts summarized process data from Cb Enterprise Response ',
-    version='0.1',
+    description='Extracts summarized process data from EDR platforms',
+    version='2.0',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -36,6 +36,6 @@ setup(
         'Programming Language :: Python',
         ],
     install_requires=[
-        'cbapi==1.7.0', 'click', 'requests', 'tqdm'
+        'cbapi==1.7.0', 'click', 'requests', 'tqdm', 'carbon-black-cloud-sdk'
         ]
     )

--- a/surveyor.py
+++ b/surveyor.py
@@ -156,7 +156,7 @@ def s1(ctx, site_id: Optional[Tuple], account_id: Optional[Tuple], account_name:
 
 @cli.command('cbc', help="Query VMware Cb Enterprise EDR")
 @click.pass_context
-def cbth(ctx):
+def cbc(ctx):
     survey(ctx, 'cbc')
 
 


### PR DESCRIPTION
- Replace `cbapi` with `cbc_sdk` in the CbC product file, requirements file, and setup.py
- Update name, url, description, version in setup.py
- Remove python version check for CbC
- Fix bug so CbC description shows properly in help menu (see below)

Before: 
```
Commands:
  cbc  Query cbc
  cbr  Query Cb Response
  dfe  Query Microsoft Defender for Endpoints
  s1   Query SentinelOne
```

After
```
Commands:
  cbc  Query VMware Cb Enterprise EDR
  cbr  Query Cb Response
  dfe  Query Microsoft Defender for Endpoints
  s1   Query SentinelOne
```