### PR TITLE
Fixed query options and added support for process name for SentinelOne

### DIFF
--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -331,7 +331,11 @@ class SentinelOne(Product):
 
     def process_search(self, tag: Tag, base_query: dict, query: str) -> None:
         build_query, from_date, to_date = self.build_query(base_query)
-        query = query + build_query
+        query = dict(map(lambda x: x.split(':'), query.split(',')))
+        query, from_date, to_date = self.build_query(query)
+        
+        if build_query:
+            query = query + build_query
         self._echo(f'Built Query: {query}')
 
         if tag not in self._queries:

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -363,7 +363,7 @@ class SentinelOne(Product):
                     search_value = f'({all_terms})'
                     operator = 'in contains anycase'
                 else:
-                    operator = 'contains'
+                    operator = 'containscis'
 
                 if tag not in self._queries:
                     self._queries[tag] = list()

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -331,11 +331,7 @@ class SentinelOne(Product):
 
     def process_search(self, tag: Tag, base_query: dict, query: str) -> None:
         build_query, from_date, to_date = self.build_query(base_query)
-        query = dict(map(lambda x: x.split(':'), query.split(',')))
-        query, from_date, to_date = self.build_query(query)
-        
-        if build_query:
-            query = query + build_query
+        query = query + build_query
         self._echo(f'Built Query: {query}')
 
         if tag not in self._queries:

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -205,11 +205,6 @@ class SentinelOne(Product):
                     query_base += ' AND '
 
                 query_base += f' UserName containscis "{value}"'
-            elif key == 'process_name':
-                if query_base:
-                    query_base += ' AND '
-
-                query_base += f' ProcessName containscis "{value}"'
             else:
                 self._echo(f'Query filter {key} is not supported by product {self.product}', logging.WARNING)
 

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -205,6 +205,11 @@ class SentinelOne(Product):
                     query_base += ' AND '
 
                 query_base += f' UserName containscis "{value}"'
+            elif key == 'process_name':
+                if query_base:
+                    query_base += ' AND '
+
+                query_base += f' ProcessName containscis "{value}"'
             else:
                 self._echo(f'Query filter {key} is not supported by product {self.product}', logging.WARNING)
 


### PR DESCRIPTION
Fixed type mismatch to allow proper query string conversion to dictionary to properly convert anything specified in --query.
Changed operator to containscis for definition files (better result confidence).
Added process_name query conversion for SentinelOne.

closes #73 