### PR TITLE
Allow SiteID and/or AccountID in CommandLine

### DIFF
--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -188,7 +188,7 @@ class SentinelOne(Product):
         """
         Get the default request body for a SentinelOne API query.
         """
-        return {"siteIds": self._site_ids} if self._site_ids else {"accountIds": [self._account_ids]}
+        return {"siteIds": self._site_ids} if self._site_ids else {"accountIds": self._account_ids}
 
     def _get_default_header(self):
         """

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -134,8 +134,10 @@ class SentinelOne(Product):
                 if id not in site_ids:
                     site_ids.append(id)
 
-        if 'account_name' in config[self.profile] and config[self.profile]['account_name'] not in account_names:
-            account_names.append(config[self.profile]['account_name'])
+        if 'account_name' in config[self.profile]:
+            for name in config[self.profile]['account_name'].split(','):
+                if name not in account_names:
+                    account_names.append(name)
 
         # determine site IDs to query (default is all)
         self._site_ids = site_ids

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -170,12 +170,11 @@ class SentinelOne(Product):
         diff = list(set(account_names) - set(temp_account_name))
         if len(diff) > 0:
             self.log.warning(f'Account names {",".join(diff)} not found')
-
+        temp_site_ids = list()
         if site_ids: # ensure specified site IDs are valid and not already covered by the account_ids listed above
             response = self._get_all_paginated_data(self._build_url('/web/api/v2.1/sites'),
                                                     params={'siteIds': ','.join(site_ids)},
                                                     add_default_params=False)
-            temp_site_ids = list()
             for item in response:
                 for site in item['sites']:
                     temp_site_ids.append(site['id'])

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -171,7 +171,7 @@ class SentinelOne(Product):
             temp_account_name = list()
             for name in account_names:
                 response = self._get_all_paginated_data(self._build_url('/web/api/v2.1/accounts'),
-                                                        params={'name': name},
+                                                        params={'states': "active", 'name': name},
                                                         add_default_params=False)
 
                 if 'errors' in response:

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -387,6 +387,7 @@ class SentinelOne(Product):
                     return self._get_all_paginated_data(self._build_url('/web/api/v2.1/dv/events'),
                                                         params={'queryId': query_id},
                                                         no_progress=False,
+                                                        add_default_params=False,
                                                         progress_desc='Retrieving query results')
                 else:
                     # query-status endpoint has a one request per second rate limit

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -200,7 +200,7 @@ class SentinelOne(Product):
                 counter += 1
                 if counter == 10 or i == len(site_ids) - 1:
                     response = self._get_all_paginated_data(self._build_url('/web/api/v2.1/sites'),
-                                                            params={'siteIds': ','.join(site_ids)},
+                                                            params={'state': "active", 'siteIds': ','.join(site_ids)},
                                                             add_default_params=False)
 
                     if 'errors' in response:

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -146,7 +146,7 @@ class SentinelOne(Product):
                 counter += 1
                 if counter == 10 or i == len(account_ids) - 1:
                     response = self._get_all_paginated_data(self._build_url(f'/web/api/v2.1/accounts'),
-                                                            params={'ids': ','.join(temp_list)},
+                                                            params={'states': "active", 'ids': ','.join(temp_list)},
                                                             add_default_params=False)
 
                     if 'errors' in response:

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -129,8 +129,10 @@ class SentinelOne(Product):
                 if id not in account_ids:
                     account_ids.append(id)
 
-        if 'site_id' in config[self.profile] and config[self.profile]['site_id'] not in site_ids:
-            site_ids.append(config[self.profile]['site_id'])
+        if 'site_id' in config[self.profile]:
+            for id in config[self.profile]['site_id'].split(','):
+                if id not in site_ids:
+                    site_ids.append(id)
 
         if 'account_name' in config[self.profile] and config[self.profile]['account_name'] not in account_names:
             account_names.append(config[self.profile]['account_name'])

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -124,8 +124,10 @@ class SentinelOne(Product):
         account_names = account_name if account_name else list()
 
         # extract account/site ID from configuration if set
-        if 'account_id' in config[self.profile] and config[self.profile]['account_id'] not in account_ids:
-            account_ids.append(config[self.profile]['account_id'])
+        if 'account_id' in config[self.profile]:
+            for id in config[self.profile]['account_id'].split(','):
+                if id not in account_ids:
+                    account_ids.append(id)
 
         if 'site_id' in config[self.profile] and config[self.profile]['site_id'] not in site_ids:
             site_ids.append(config[self.profile]['site_id'])

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -470,11 +470,6 @@ class SentinelOne(Product):
                 # merge all query tags into a single string
                 merged_tag = Tag(','.join(tag.tag for tag in merged_tags), ','.join(str(tag.data) for tag in merged_tags))
 
-                if len(self._site_ids):
-                    # restrict query to specified sites
-                    # S1QL does not support restricting a query to a specified account ID
-                    merged_query = f'SiteID in contains ("' + '", "'.join(self._site_ids) + f'") AND ({merged_query})'
-
                 # build request body for DV API call
                 params = self._get_default_body()
                 params.update({

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -170,8 +170,10 @@ class SentinelOne(Product):
         diff = list(set(account_names) - set(temp_account_name))
         if len(diff) > 0:
             self.log.warning(f'Account names {",".join(diff)} not found')
-        temp_site_ids = list()
+
+        
         if site_ids: # ensure specified site IDs are valid and not already covered by the account_ids listed above
+            temp_site_ids = list()
             response = self._get_all_paginated_data(self._build_url('/web/api/v2.1/sites'),
                                                     params={'siteIds': ','.join(site_ids)},
                                                     add_default_params=False)
@@ -181,9 +183,9 @@ class SentinelOne(Product):
                     if site['accountId'] not in self._account_ids and site['id'] not in self._site_ids:
                         self._site_ids.append(site['id'])
 
-        diff = list(set(site_ids) - set(temp_site_ids))
-        if len(diff) > 0:
-            self.log.warning(f'Site IDs {",".join(diff)} not found')
+            diff = list(set(site_ids) - set(temp_site_ids))
+            if len(diff) > 0:
+                self.log.warning(f'Site IDs {",".join(diff)} not found')
 
         # remove unncessary variables from self
         self.__dict__.pop('site_id',None)

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -7,7 +7,6 @@ from tqdm import tqdm
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Optional, Tuple, Callable
-import sys
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -509,11 +508,6 @@ class SentinelOne(Product):
                 if len(self._query_base):
                     # add base_query filter to merged query string
                     merged_query = f'{self._query_base} AND ({merged_query})'
-                    
-                if len(self._site_ids):
-                    # restrict query to specified sites
-                    # S1QL does not support restricting a query to a specified account ID
-                    merged_query = f'SiteID in contains ("' + '", "'.join(self._site_ids) + f'") AND ({merged_query})'
                 
                 # build request body for DV API call
                 params = self._get_default_body()

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -127,17 +127,17 @@ class SentinelOne(Product):
         if 'account_id' in config[self.profile]:
             for id in config[self.profile]['account_id'].split(','):
                 if id not in account_ids:
-                    account_ids.append(id)
+                    account_ids.append(id.strip())
 
         if 'site_id' in config[self.profile]:
             for id in config[self.profile]['site_id'].split(','):
                 if id not in site_ids:
-                    site_ids.append(id)
+                    site_ids.append(id.strip())
 
         if 'account_name' in config[self.profile]:
             for name in config[self.profile]['account_name'].split(','):
                 if name not in account_names:
-                    account_names.append(name)
+                    account_names.append(name.strip())
 
         # determine site IDs to query (default is all)
         self._site_ids = site_ids


### PR DESCRIPTION
Changes
- Modify order of requirement checks so both cmdline and config file site_ids and account_ids are processed before checking for missing data
  - Have cmdline input take precedence over config file settings
    - If site IDs/account IDs/account names are provided as cmdline parameters, ignore config file options
  - Process account_ids and account_name before site_ids 
    - If a site_id is already covered by an account_id, only use account_id
  - Log a warning if account_id, account_name, or site_id is not found
  - Save both account_id and site_id in _get_default_body()
  - Remove SiteID from merged query since that is already defined in _get_default_body()
  - Remove GET request to `/web/api/v2.1/agents/count` since API key validation naturally occurs in `_get_site_ids()`
- This reordering will also account for the default profile issue

Closes #75 and #76