### PR TITLE
Upgrade cbapi to support Python 3.10+

### DIFF
--- a/load.py
+++ b/load.py
@@ -1,8 +1,5 @@
 import os
-import sys
 from typing import Type, Iterable
-
-import click
 
 from common import Product
 
@@ -13,11 +10,6 @@ for module in os.listdir(os.path.join(os.path.dirname(__file__), 'products')):
         continue
 
     sub_module = module[:-3]
-
-    # cbapi module has broken imports for Python 3.10+
-    # importing it here would result in none of the products working on Python 3.10+
-    if sub_module == 'vmware_cb_response':
-        continue
 
     __import__('products.' + sub_module, locals(), globals())
     del module
@@ -42,14 +34,6 @@ def get_product_instance(product: str, **kwargs) -> Product:
     """
     Get an instance of the product implementation matching the specified product string.
     """
-    if product == 'cbr':
-        if sys.version_info.major == 3 and sys.version_info.minor > 9:
-            click.secho(f'cbr only functions on Python 3.9 due to a library limitation', fg='red')
-            exit(1)
-
-        from products.vmware_cb_response import CbResponse
-        return CbResponse(**kwargs)
-
     for subclass in _get_subclasses():
         if subclass.product == product:
             return subclass(**kwargs)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click~=8.0.4
-cbapi~=1.7.0
+cbapi~=1.7.9
 requests~=2.27.1
 setuptools~=60.6.0
 tqdm~=4.63.0


### PR DESCRIPTION
Changes
- Updated requirements.txt to use new cbapi version
- Removed import bypass for cbapi that required python 3.9