### PR TITLE
Added Support for "Query" Field in Definition Files

### DIFF
--- a/products/microsoft_defender_for_endpoints.py
+++ b/products/microsoft_defender_for_endpoints.py
@@ -120,8 +120,9 @@ class DefenderForEndpoints(Product):
                 if search_field == 'query':
                     if isinstance(terms, list):
                         if len(terms) > 1:
-                            self.log.warning(f'The "query" field only supports a single term. Will use the first time during processing')
-                        query = terms[0]
+                            query = ' '.join(terms)
+                        else:
+                            query = terms[0]
                     else:
                         query = terms
                 else:

--- a/products/vmware_cb_enterprise_edr.py
+++ b/products/vmware_cb_enterprise_edr.py
@@ -37,8 +37,8 @@ class CbEnterpriseEdr(Product):
     _conn: CBCloudAPI  # CB Cloud API
 
     def __init__(self, profile: str, **kwargs):
-        self._device_group = kwargs['device_group']
-        self._device_policy = kwargs['device_policy']
+        self._device_group = kwargs['device_group'] if 'device_group' in kwargs else None
+        self._device_policy = kwargs['device_policy'] if 'device_group' in kwargs else None
 
         super().__init__(self.product, profile, **kwargs)
 
@@ -121,8 +121,9 @@ class CbEnterpriseEdr(Product):
                 if search_field == 'query':
                     if isinstance(terms, list):
                         if len(terms) > 1:
-                            self.log.warning(f'The "query" field only supports a single term. Will use the first time during processing')
-                        query = terms[0]
+                            query = '('+ ') OR ('.join(terms) + ')'
+                        else:
+                            query = terms[0]
                     else:
                         query = terms
                 else:

--- a/products/vmware_cb_response.py
+++ b/products/vmware_cb_response.py
@@ -11,7 +11,7 @@ class CbResponse(Product):
     _conn: CbEnterpriseResponseAPI  # CB Response API
 
     def __init__(self, profile: str, **kwargs):
-        self._sensor_group = kwargs['sensor_group']
+        self._sensor_group = kwargs['sensor_group'] if 'sensor_group' in kwargs else None
 
         super().__init__(self.product, profile, **kwargs)
 

--- a/products/vmware_cb_response.py
+++ b/products/vmware_cb_response.py
@@ -71,8 +71,9 @@ class CbResponse(Product):
                 if search_field == 'query':
                     if isinstance(terms, list):
                         if len(terms) > 1:
-                            self.log.warning(f'The "query" field only supports a single term. Will use the first term during processing')
-                        query = terms[0]
+                            query = '(' + ') OR ('.join(terms) + ')'
+                        else:
+                            query = terms[0]
                     else:
                         query = terms
                 else:


### PR DESCRIPTION
Changes:
- Updated CbR, CbC, and DFE to support a "query" field in the definition files
  - This query field is EDR-specific so the script will not try to convert the language.
  - No checks are performed to verify the query language but error handling is in place to gracefully fail if language is unsupported.
- Updated DFE query builder to use the same tables for individual queries and definition file searches

To-Do After Merge:
- Update documentation for this new feature
- Update definition file `Incident_202103_Exchange_Activity` to use new "query" field

Closes #12 