### PR TITLE
Implement PowerQuery support for SentinelOne

### DIFF
--- a/common.py
+++ b/common.py
@@ -6,6 +6,10 @@ from typing import Tuple, Optional, Any, Union
 from help import log_echo
 
 
+class AuthenticationError(Exception):
+    pass
+
+
 @dataclass(eq=True, frozen=True)
 class Tag:
     tag: str
@@ -27,7 +31,7 @@ class Product(ABC):
 
     Subclasses must implement all abstract methods and invoke this class's constructor.
     """
-    product: str = None  # a string describing the product (e.g. cbr/cbth/defender/s1)
+    product: Optional[str] = None  # a string describing the product (e.g. cbr/cbth/defender/s1)
     profile: str  # the profile is used to authenticate to the target platform
     _results: dict[Tag, list[Result]]
     log: logging.Logger
@@ -120,7 +124,7 @@ class Product(ABC):
         Add results to the result store.
         """
         if not tag:
-            tag = '_default'
+            tag = Tag('_default')
 
         if tag not in self._results:
             self._results[tag] = list()

--- a/common.py
+++ b/common.py
@@ -1,7 +1,7 @@
 import logging
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
-from typing import Tuple, Optional, Any, Union
+from dataclasses import dataclass
+from typing import Tuple, Optional, Any
 
 from help import log_echo
 

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -54,7 +54,10 @@ PARAMETER_MAPPING_PQ: dict[str, str] = {
     'cmdline': 'src.process.cmdline',
     'digsig_publisher': 'src.process.publisher',
     'domain': 'url.address',
-    'internal_name': 'tgt.file.internalName'
+    'filemod':'tgt.file.path',
+    'internal_name': 'tgt.file.internalName',
+    'modload': 'module.path',
+    'process_file_description': 'src.process.displayName'
 }
 
 

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -582,7 +582,10 @@ class SentinelOne(Product):
             query_id = body['data']['queryId']
             self.log.info(f'Query ID is {query_id}')
 
-            events = self._get_dv_events(query_id, p_bar=p_bar, cancel_event=cancel_event)
+            if self._pq and body['data']['status'] == 'FINISHED': # If using PQ, the results can be returned immediately
+                events = body['data']['data']
+            else:
+                events = self._get_dv_events(query_id, p_bar=p_bar, cancel_event=cancel_event)
             self.log.debug(f'Got {len(events)} events')
 
             self._results[merged_tag] = list()

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -499,8 +499,11 @@ class SentinelOne(Product):
 
             for tag, queries in self._queries.items():
                 for query in queries:
-                    full_query = f'{query.parameter} {query.operator} {query.search_value}'
-                    query_text.append((tag, full_query))
+                    if query.full_query is not None:
+                        query_text.append((tag, query.full_query))
+                    else:
+                        full_query = f'{query.parameter} {query.operator} {query.search_value}'
+                        query_text.append((tag, full_query))
         else:
             # key is a tuple of the query operator and parameter
             # value is a list of Tuples where each tuple contains the query tag and search value

--- a/surveyor.py
+++ b/surveyor.py
@@ -142,13 +142,16 @@ def cli(ctx, prefix: Optional[str], hostname: Optional[str], profile: str, days:
 @click.option("--account-id", help="ID of SentinelOne account to query", multiple=True, default=None)
 @click.option("--account-name", help="Name of SentinelOne account to query", multiple=True, default=None)
 @click.option("--creds", 'creds', help="Path to credential file", type=click.Path(exists=True), required=True)
+@click.option("--pq", 'pq', help="Use PowerQuery for queries", is_flag=True, required=False)
 @click.pass_context
-def s1(ctx, site_id: Optional[Tuple], account_id: Optional[Tuple], account_name: Optional[Tuple], creds: Optional[str]):
+def s1(ctx, site_id: Optional[Tuple], account_id: Optional[Tuple], account_name: Optional[Tuple], creds: Optional[str],
+       pq: bool):
     ctx.obj.product_args = {
         'creds_file': creds,
         'site_id': list(site_id),
         'account_id': list(account_id),
-        'account_name': list(account_name)
+        'account_name': list(account_name),
+        'pq': pq
     }
 
     survey(ctx, 's1')

--- a/surveyor.py
+++ b/surveyor.py
@@ -142,19 +142,20 @@ def cli(ctx, prefix: Optional[str], hostname: Optional[str], profile: str, days:
 @click.option("--account-id", help="ID of SentinelOne account to query", multiple=True, default=None)
 @click.option("--account-name", help="Name of SentinelOne account to query", multiple=True, default=None)
 @click.option("--creds", 'creds', help="Path to credential file", type=click.Path(exists=True), required=True)
-@click.option("--pq", 'pq', help="Use PowerQuery for queries", is_flag=True, required=False)
+@click.option("--dv", 'dv', help="Use Deep Visibility for queries", is_flag=True, required=False)
 @click.pass_context
 def s1(ctx, site_id: Optional[Tuple], account_id: Optional[Tuple], account_name: Optional[Tuple], creds: Optional[str],
-       pq: bool):
+       dv: bool):
     ctx.obj.product_args = {
         'creds_file': creds,
         'site_id': list(site_id),
         'account_id': list(account_id),
         'account_name': list(account_name),
-        'pq': pq
+        'pq': not dv
     }
 
     survey(ctx, 's1')
+
 
 # CbC options
 @cli.command('cbc', help="Query VMware Cb Enterprise EDR")
@@ -168,6 +169,7 @@ def cbc(ctx, device_group: Optional[Tuple], device_policy: Optional[Tuple]):
     }
 
     survey(ctx, 'cbc')
+
 
 # CbR Options
 @cli.command('cbr', help="Query VMware Cb Response")


### PR DESCRIPTION
This PR implements PowerQuery support for the SentinelOne product. 

**Benefits of PowerQuery (PQ) over Deep Visibility (DV):**
- Lack of a 1req/min rate limit allows product to perform a separate query per search criteria, resulting in more useful output
- Ability to perform a query per search criteria helps reduce the impact of the 20k search result limit

**Discussion Points:**
- Which mode should be the default, PQ or DV? PQ provides faster and more accurate search results, but I am not sure if it is available across all S1 consoles. This PR currently sets PQ as the default and allows falling back to DV with the `--dv` product flag.
- PQ does not respect Site ID filters unless the parent Account ID is also included in the query. This means that if the user provides both an Account ID and a nested Site ID, we cannot assume that only the Account ID should be queried (as we currently do in DV mode). This PR automatically adds the Account ID when only a Site ID is provided by the user. This logic difference between DV and PQ may be confusing to users.
- Having both PQ and DV implementations makes the code somewhat harder to understand due to frequent branching logic. If we determine that PowerQuery can be assumed to be globally available, we may want to consider removing DV support in the future.

**Testing:**
- I have tested PQ and DV searches with various definition files and haven't noticed any issues.