### PR TITLE
Update remote-admin.json

### DIFF
--- a/definitions/remote-admin.json
+++ b/definitions/remote-admin.json
@@ -42,7 +42,7 @@
         "digsig_publisher": ["ConnectWise, LLC"]
     },
     "Chrome Remote Desktop": {
-        "cmdline": ["cmdline:efmjfjelnicpmdcmfikempdhlmainjcb*"],
+        "cmdline": ["efmjfjelnicpmdcmfikempdhlmainjcb*"],
         "domain": ["remotedesktop.google.com"]
     },
     "DameWare": { 


### PR DESCRIPTION
Removed "cmdline:" from line 45 of remote-admin.json definition file. This was causing Surveyor to error out when querying Chrome Remote Desktop.