### PR TITLE
feat(hackingai): add ai/ml tools EDR detections

### DIFF
--- a/definitions/hackingai.json
+++ b/definitions/hackingai.json
@@ -14,7 +14,7 @@
     },
     "ray.io": {
         "process_name": ["gcs_server", "raylet"],
-        "cmdline": ["ray", "gcs_server", "ray/_private/log_monitor.py", "ray/_private/runtime_env/agent/main.py", "ray/autoscaler/_private/monitor.py", "ray/_private/workers/default_worker.py", "ray/dashboard/dashboard.py", "ray/raylet/raylet"],
+        "cmdline": ["gcs_server", "ray/_private/log_monitor.py", "ray/_private/runtime_env/agent/main.py", "ray/autoscaler/_private/monitor.py", "ray/_private/workers/default_worker.py", "ray/dashboard/dashboard.py", "ray/raylet/raylet"],
         "domain": ["ray.io"]
     }
 }

--- a/definitions/hackingai.json
+++ b/definitions/hackingai.json
@@ -1,0 +1,32 @@
+{
+
+    "mlflow": {
+        "process_name": ["python*.exe",
+                         "python*",
+                         "pip*"],
+
+        "cmdline": ["mlflow"],
+        "domain": ["mlflow.org"]
+    },
+    "h2o.ai": {
+        "process_name": ["python*.exe",
+                         "python*",
+                         "pip*",
+                         "java*",
+                         "hadoop*"],
+        "cmdline": ["h2o-driver.jar", "h2odriver.jar", "h2o", "/h2o_"],
+        "domain": ["h2o.ai", "h2o-release.s3.amazonaws.com"],
+		"ipaddr":[
+			"228.246.114.236",
+			"ff05:0:3ff6:72ec:0:0:3ff6:72ec"
+		]
+    },
+    "ray.io": {
+        "process_name": ["python*.exe",
+                         "python*",
+                         "pip*",
+                         "gcs_server", "raylet"],
+        "cmdline": ["ray", "gcs_server", "ray/_private/log_monitor.py", "ray/_private/runtime_env/agent/main.py", "ray/autoscaler/_private/monitor.py", "ray/_private/workers/default_worker.py", "ray/dashboard/dashboard.py", "ray/raylet/raylet"],
+        "domain": ["ray.io"]
+    }
+}

--- a/definitions/hackingai.json
+++ b/definitions/hackingai.json
@@ -1,18 +1,11 @@
 {
 
     "mlflow": {
-        "process_name": ["python*.exe",
-                         "python*",
-                         "pip*"],
-
         "cmdline": ["mlflow"],
         "domain": ["mlflow.org"]
     },
     "h2o.ai": {
-        "process_name": ["python*.exe",
-                         "python*",
-                         "pip*",
-                         "java*",
+        "process_name": ["java*",
                          "hadoop*"],
         "cmdline": ["h2o-driver.jar", "h2odriver.jar", "h2o", "/h2o_"],
         "domain": ["h2o.ai", "h2o-release.s3.amazonaws.com"],
@@ -22,10 +15,7 @@
 		]
     },
     "ray.io": {
-        "process_name": ["python*.exe",
-                         "python*",
-                         "pip*",
-                         "gcs_server", "raylet"],
+        "process_name": ["gcs_server", "raylet"],
         "cmdline": ["ray", "gcs_server", "ray/_private/log_monitor.py", "ray/_private/runtime_env/agent/main.py", "ray/autoscaler/_private/monitor.py", "ray/_private/workers/default_worker.py", "ray/dashboard/dashboard.py", "ray/raylet/raylet"],
         "domain": ["ray.io"]
     }

--- a/definitions/hackingai.json
+++ b/definitions/hackingai.json
@@ -5,8 +5,6 @@
         "domain": ["mlflow.org"]
     },
     "h2o.ai": {
-        "process_name": ["java*",
-                         "hadoop*"],
         "cmdline": ["h2o-driver.jar", "h2odriver.jar", "h2o", "/h2o_"],
         "domain": ["h2o.ai", "h2o-release.s3.amazonaws.com"],
 		"ipaddr":[


### PR DESCRIPTION
AI development tools hunt to ensure align with company guidance:

Quick review to detect some common AI tools with vulnerabilities based on EDR data
Possible false-positive cmdline arguments for mlflow that may want to exclude but not sure if variable for that: "--disable-mlflow", "--skip-mlflow", "--skip_mlflow"
There would be additional patterns for web url path but I don't think there is a variable for it either (ex: "/ajax-api/2.0/preview/mlflow/")

Inspired from
https://protectai.com/blog/hacking-ai-system-takeover-in-mlflow-strikes-again-and-again
https://protectai.com/threat-research/november-vulnerability-report
https://docs.h2o.ai/h2o/latest-stable/h2o-docs/starting-h2o.html#multicast
https://docs.ray.io/en/latest/ray-security/index.html