### PR TITLE
Resolve S1 site id filtering

### DIFF
--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -95,16 +95,18 @@ class SentinelOne(Product):
     def __init__(self, pq: bool = False, **kwargs):
   
         self.profile = kwargs['profile'] if 'profile' in kwargs else 'default'
-        self._site_ids = kwargs['site_ids'] if 'site_ids' in kwargs else []
-        self._account_ids = kwargs['account_ids'] if 'account_ids' in kwargs else []
-        self._account_names = kwargs['account_names'] if 'account_names' in kwargs else []
+        self._site_ids = kwargs.get('site_id', []) or list()
+        self._account_ids = kwargs.get('account_id', []) or list()
+        self._account_names = kwargs.get('account_name', []) or list()
         self._url = kwargs['url'] if 'url' in kwargs else ''
         self._token = kwargs['token'] if 'token' in kwargs else None
         self.creds_file = kwargs['creds_file'] if 'creds_file' in kwargs else None
         self._raw = kwargs['raw'] if 'raw' in kwargs else self._raw
         limit = (kwargs['limit']) if 'limit' in kwargs else 0
         self._pq = pq # This supports command-line options, will default to Power Query
-        
+        print(kwargs)
+        print(self._account_ids)
+        print(self._site_ids)
         # Will check for passed-in arguments; if none are present, it will default to Deep Visibility. Non-command line.
         if 'deep_visibility' in kwargs:
             self._pq = False if kwargs.get('deep_visibility', "False") == "True" else True
@@ -264,16 +266,18 @@ class SentinelOne(Product):
                     for item in response:
                         for site in item['sites']:
                             temp_site_ids.append(site['id'])
-
-                            if self._pq and site['id'] not in self._site_ids:
-                                self._site_ids.append(site['id'])
+ 
+                            if self._pq:
+                                if site['id'] not in self._site_ids:
+                                    self._site_ids.append(site['id'])
 
                                 if site['accountId'] not in self._account_ids:
-                                    # PowerQuery won't honor Site ID filters unless the parent account ID is also
+                                    # PowerQuery won't honor Site ID filters unless the parent accousnt ID is also
                                     # included in the request body
                                     self._account_ids.append(site['accountId'])
                             elif site['accountId'] not in self._account_ids and site['id'] not in self._site_ids:
-                                self._site_ids.append(site['id'])
+                                self._site_ids.append(site['id']) 
+
                     counter = 0
                     temp_list = []
                 i += 1

--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -104,9 +104,7 @@ class SentinelOne(Product):
         self._raw = kwargs['raw'] if 'raw' in kwargs else self._raw
         limit = (kwargs['limit']) if 'limit' in kwargs else 0
         self._pq = pq # This supports command-line options, will default to Power Query
-        print(kwargs)
-        print(self._account_ids)
-        print(self._site_ids)
+
         # Will check for passed-in arguments; if none are present, it will default to Deep Visibility. Non-command line.
         if 'deep_visibility' in kwargs:
             self._pq = False if kwargs.get('deep_visibility', "False") == "True" else True


### PR DESCRIPTION
Resolves filtering issues with SentinelOne when specifying id filters in the cmdline. it also fixes a code check validating the account id is always added when site ids are in use. It should be noted that PQ does not require an account id but the code was left as it was as a safety precaution in case API requirements change in the future. Including both account and site ids will result in the same output as just specifying the site id and it will also avoid if there is ever a site id collision among multiple account ids.

Resolves #155 