### PR TITLE
Update S1 PowerQuery Columns in CSV output

### DIFF
--- a/products/sentinel_one.py
+++ b/products/sentinel_one.py
@@ -649,14 +649,24 @@ class SentinelOne(Product):
             self.log.debug(f'Got {len(events)} events')
 
             self._results[merged_tag] = list()
-            
             for event in events:
                 if self._pq:
                     hostname = event[0]
                     username = event[1]
                     path = event[2]
+                    srcprocdisplayname = event[8]
+                    tgtprocdisplayname = event[9]
+                    tgtfilepath = event[10]
+                    tgtfilesha1 = event[11]
+                    tgtfilesha256 = event[12]
+                    scrprocparentimagepath = event[13]
+                    tgtprocimagepath = event[14]
+                    url = event[15]
+                    srcip = event[16]
+                    dstip = event[17]
+                    dnsrequest = event[18]
                     command_line = event[3]
-                    additional_data = (event[8], event[9], event[10], event[11],'None','None','None','None','None','None','None','None','None','None','None','None')
+                    additional_data = (event[4], event[5], event[6], event[7], srcprocdisplayname, scrprocparentimagepath, tgtprocdisplayname, tgtprocimagepath, tgtfilepath, tgtfilesha1, tgtfilesha256, url, srcip, dstip, dnsrequest, event[19])
                 else:
                     hostname = event['endpointName']
                     username = event['srcProcUser']
@@ -761,9 +771,11 @@ class SentinelOne(Product):
                             merged_query += ')'
 
                         merged_query += ' | group count() by endpoint.name, src.process.user, ' \
-                                        'src.process.image.path, src.process.cmdline, src.process.name, ' \
-                                        'src.process.publisher, url.address, tgt.file.internalName, src.process.startTime, ' \
-                                        'site.id, site.name, src.process.storyline.id'
+                                        'src.process.image.path, src.process.cmdline, event.time, ' \
+                                        'site.id, site.name, src.process.storyline.id, src.process.displayname, ' \
+                                        'src.process.parent.image.path, tgt.process.displayname, tgt.process.image.path, ' \
+                                        'tgt.file.path, tgt.file.sha1, tgt.file.sha256, url.address, src.ip.address, ' \
+                                        'dst.ip.address, event.dns.request, event.type'
                     
                     self.log.debug(f'Appending query to executor: {merged_query}')
                     futures.append(executor.submit(self._run_query, merged_query, start_date, end_date, merged_tag,

--- a/tests/test_sentinel_one.py
+++ b/tests/test_sentinel_one.py
@@ -414,26 +414,34 @@ def test_process_queries_pq(s1_product : SentinelOne, mocker):
              'OR src.process.name contains svchost.exe OR src.process.name contains notepad.exe OR src.process.name contains ' + 
              'explorer.exe OR src.process.name contains firefox.exe OR src.process.name contains chrome.exe ' + 
              '| group count() by endpoint.name, src.process.user, ' +
-             'src.process.image.path, src.process.cmdline, src.process.name, ' +
-             'src.process.publisher, url.address, tgt.file.internalName, src.process.startTime, ' + 
-             'site.id, site.name, src.process.storyline.id', 
+             'src.process.image.path, src.process.cmdline, event.time, ' +
+             'site.id, site.name, src.process.storyline.id, src.process.displayname, ' +
+             'src.process.parent.image.path, tgt.process.displayname, tgt.process.image.path, ' +
+             'tgt.file.path, tgt.file.sha1, tgt.file.sha256, url.address, src.ip.address, ' +
+             'dst.ip.address, event.dns.request, event.type', 
              ANY, ANY, Tag('valueA', data=None), ANY, False),
         call('src.process.name contains iexplore.exe | group count() by endpoint.name, src.process.user, ' +
-             'src.process.image.path, src.process.cmdline, src.process.name, ' +
-             'src.process.publisher, url.address, tgt.file.internalName, src.process.startTime, ' +
-             'site.id, site.name, src.process.storyline.id', ANY, ANY, Tag('valueA', data=None), ANY, False),
+             'src.process.image.path, src.process.cmdline, event.time, ' +
+             'site.id, site.name, src.process.storyline.id, src.process.displayname, ' +
+             'src.process.parent.image.path, tgt.process.displayname, tgt.process.image.path, ' +
+             'tgt.file.path, tgt.file.sha1, tgt.file.sha256, url.address, src.ip.address, ' +
+             'dst.ip.address, event.dns.request, event.type',  ANY, ANY, Tag('valueA', data=None), ANY, False),
         call('event.dns.request contains google.com OR event.dns.request contains microsoft.com OR event.dns.request contains amazon.com OR event.dns.request contains bing.com ' + 
              'OR event.dns.request contains yahoo.com OR event.dns.request contains github.com OR event.dns.request contains virustotal.com OR event.dns.request contains facebook.com ' + 
              'OR event.dns.request contains twitter.com OR event.dns.request contains spotify.com ' + 
              '| group count() by endpoint.name, src.process.user, ' +
-             'src.process.image.path, src.process.cmdline, src.process.name, ' +
-             'src.process.publisher, url.address, tgt.file.internalName, src.process.startTime, ' +
-             'site.id, site.name, src.process.storyline.id',
+             'src.process.image.path, src.process.cmdline, event.time, ' +
+             'site.id, site.name, src.process.storyline.id, src.process.displayname, ' +
+             'src.process.parent.image.path, tgt.process.displayname, tgt.process.image.path, ' +
+             'tgt.file.path, tgt.file.sha1, tgt.file.sha256, url.address, src.ip.address, ' +
+             'dst.ip.address, event.dns.request, event.type', 
              ANY, ANY, Tag('valueB', data=None), ANY, False),
         call('event.dns.request contains apple.com | group count() by endpoint.name, src.process.user, ' +
-             'src.process.image.path, src.process.cmdline, src.process.name, ' +
-             'src.process.publisher, url.address, tgt.file.internalName, src.process.startTime, ' +
-             'site.id, site.name, src.process.storyline.id', ANY, ANY, Tag('valueB', data=None), ANY, False)
+             'src.process.image.path, src.process.cmdline, event.time, ' +
+             'site.id, site.name, src.process.storyline.id, src.process.displayname, ' +
+             'src.process.parent.image.path, tgt.process.displayname, tgt.process.image.path, ' +
+             'tgt.file.path, tgt.file.sha1, tgt.file.sha256, url.address, src.ip.address, ' +
+             'dst.ip.address, event.dns.request, event.type',  ANY, ANY, Tag('valueB', data=None), ANY, False)
     ])
 
 def test_process_queries_pq_single_site_id(s1_product : SentinelOne, mocker):
@@ -455,9 +463,11 @@ def test_process_queries_pq_single_site_id(s1_product : SentinelOne, mocker):
     mocked_run_query.assert_has_calls([
         call('(src.process.name contains powershell.exe) AND (site.id = 12345) ' + 
              '| group count() by endpoint.name, src.process.user, ' +
-             'src.process.image.path, src.process.cmdline, src.process.name, ' +
-             'src.process.publisher, url.address, tgt.file.internalName, src.process.startTime, ' + 
-             'site.id, site.name, src.process.storyline.id', 
+             'src.process.image.path, src.process.cmdline, event.time, ' +
+             'site.id, site.name, src.process.storyline.id, src.process.displayname, ' +
+             'src.process.parent.image.path, tgt.process.displayname, tgt.process.image.path, ' +
+             'tgt.file.path, tgt.file.sha1, tgt.file.sha256, url.address, src.ip.address, ' +
+             'dst.ip.address, event.dns.request, event.type', 
              ANY, ANY, Tag('valueA', data=None), ANY, False)
     ])
 
@@ -480,8 +490,10 @@ def test_process_queries_pq_multiple_site_ids(s1_product : SentinelOne, mocker):
     mocked_run_query.assert_has_calls([
         call('(src.process.name contains powershell.exe) AND (site.id = 12345 OR site.id = 67890) ' + 
              '| group count() by endpoint.name, src.process.user, ' +
-             'src.process.image.path, src.process.cmdline, src.process.name, ' +
-             'src.process.publisher, url.address, tgt.file.internalName, src.process.startTime, ' + 
-             'site.id, site.name, src.process.storyline.id', 
+             'src.process.image.path, src.process.cmdline, event.time, ' +
+             'site.id, site.name, src.process.storyline.id, src.process.displayname, ' +
+             'src.process.parent.image.path, tgt.process.displayname, tgt.process.image.path, ' +
+             'tgt.file.path, tgt.file.sha1, tgt.file.sha256, url.address, src.ip.address, ' +
+             'dst.ip.address, event.dns.request, event.type', 
              ANY, ANY, Tag('valueA', data=None), ANY, False)
     ])


### PR DESCRIPTION
Resolves a large amount of columns in the csv from showing "None" when S1 PowerQuery is utilized. Updating the query to return the necessary fields and mapping them to the proper columns resolves this where these fields are now properly populated.

Changes are specific to the SentinelOne product file and only affect the output presented in the csv.