### PR TITLE
Update Sigma Translator for DFE to Use Kusto Backend

### DIFF
--- a/common.py
+++ b/common.py
@@ -187,7 +187,7 @@ def sigma_translation(product: str, sigma_rules: list, pq: bool = False) -> dict
         supports_json_ouput = False
         plugins.get_plugin_by_id('microsoft365defender').install()
         from sigma.backends.kusto import KustoBackend # type: ignore
-        from sigma.pipelines.microsoft365defender import microsoft_365_defender_pipeline 
+        from sigma.pipelines.microsoft365defender import microsoft_365_defender_pipeline # type: ignore 
         backend = KustoBackend(microsoft_365_defender_pipeline())
     elif product == 'cortex':
         plugins.get_plugin_by_id('cortexxdr').install()
@@ -200,25 +200,25 @@ def sigma_translation(product: str, sigma_rules: list, pq: bool = False) -> dict
         if product == "dfe":
             rule_collection = [SigmaCollection.load_ruleset([i]) for i in sigma_rules] # load each file as a separate rule collection for DFE
         else:
-            rule_collection = SigmaCollection.load_ruleset(sigma_rules)
+            rule_collection = SigmaCollection.load_ruleset(sigma_rules) # type: ignore
     elif not any(are_files): # if none of the items in the list are files, assume YML formatted strings
         if product == 'dfe':
             rule_collection = [SigmaCollection.from_yaml(i) for i in sigma_rules] # load each YML string as a separate rule collection for DFE
         else:
-            rule_collection = SigmaCollection.merge([SigmaCollection.from_yaml(i) for i in sigma_rules])
+            rule_collection = SigmaCollection.merge([SigmaCollection.from_yaml(i) for i in sigma_rules]) # type: ignore
     else:
         logging.error("There appears to be a mix of files and YML strings. Cannot process a mixed list of values. Aborting.")
         return {'queries': []}
 
     if supports_json_ouput:
-        return backend.convert(rule_collection, "json")
+        return backend.convert(rule_collection, "json") # type: ignore
     else:
         results: dict = {"queries":[]}
         for r in rule_collection:
             results['queries'].append({
-                'query': backend.convert_rule(r)[0] if product != 'dfe' else backend.convert(r)[0],
-                'id': r.id if product != 'dfe' else r.rules[0].id,
-                'title': r.title if product != 'dfe' else r.rules[0].title,
-                'description': r.description if product != 'dfe' else r.rules[0].description
+                'query': backend.convert_rule(r)[0] if product != 'dfe' else backend.convert(r)[0], # type: ignore
+                'id': r.id if product != 'dfe' else r.rules[0].id, # type: ignore
+                'title': r.title if product != 'dfe' else r.rules[0].title, # type: ignore
+                'description': r.description if product != 'dfe' else r.rules[0].description # type: ignore
             })
         return results

--- a/common.py
+++ b/common.py
@@ -185,6 +185,7 @@ def sigma_translation(product: str, sigma_rules: list, pq: bool = False) -> dict
             backend = SentinelOneBackend()
     elif product == 'dfe':
         supports_json_ouput = False
+        plugins.get_plugin_by_id('microsoft365defender').install()
         from sigma.backends.kusto import KustoBackend # type: ignore
         from sigma.pipelines.microsoft365defender import microsoft_365_defender_pipeline 
         backend = KustoBackend(microsoft_365_defender_pipeline())

--- a/common.py
+++ b/common.py
@@ -185,9 +185,9 @@ def sigma_translation(product: str, sigma_rules: list, pq: bool = False) -> dict
             backend = SentinelOneBackend()
     elif product == 'dfe':
         supports_json_ouput = False
-        plugins.get_plugin_by_id('microsoft365defender').install()
-        from sigma.backends.microsoft365defender import Microsoft365DefenderBackend # type: ignore
-        backend = Microsoft365DefenderBackend()
+        from sigma.backends.kusto import KustoBackend # type: ignore
+        from sigma.pipelines.microsoft365defender import microsoft_365_defender_pipeline 
+        backend = KustoBackend(microsoft_365_defender_pipeline())
     elif product == 'cortex':
         plugins.get_plugin_by_id('cortexxdr').install()
         from sigma.backends.cortexxdr import CortexXDRBackend # type: ignore
@@ -196,9 +196,15 @@ def sigma_translation(product: str, sigma_rules: list, pq: bool = False) -> dict
     are_files = [os.path.isfile(i) for i in sigma_rules]
 
     if all(are_files): # if all items in the list are files
-        rule_collection = SigmaCollection.load_ruleset(sigma_rules)
+        if product == "dfe":
+            rule_collection = [SigmaCollection.load_ruleset([i]) for i in sigma_rules] # load each file as a separate rule collection for DFE
+        else:
+            rule_collection = SigmaCollection.load_ruleset(sigma_rules)
     elif not any(are_files): # if none of the items in the list are files, assume YML formatted strings
-        rule_collection = SigmaCollection.merge([SigmaCollection.from_yaml(i) for i in sigma_rules])
+        if product == 'dfe':
+            rule_collection = [SigmaCollection.from_yaml(i) for i in sigma_rules] # load each YML string as a separate rule collection for DFE
+        else:
+            rule_collection = SigmaCollection.merge([SigmaCollection.from_yaml(i) for i in sigma_rules])
     else:
         logging.error("There appears to be a mix of files and YML strings. Cannot process a mixed list of values. Aborting.")
         return {'queries': []}
@@ -209,9 +215,9 @@ def sigma_translation(product: str, sigma_rules: list, pq: bool = False) -> dict
         results: dict = {"queries":[]}
         for r in rule_collection:
             results['queries'].append({
-                'query': backend.convert_rule(r)[0],
-                'id': r.id,
-                'title': r.title,
-                'description': r.description
+                'query': backend.convert_rule(r)[0] if product != 'dfe' else backend.convert(r)[0],
+                'id': r.id if product != 'dfe' else r.rules[0].id,
+                'title': r.title if product != 'dfe' else r.rules[0].title,
+                'description': r.description if product != 'dfe' else r.rules[0].description
             })
         return results

--- a/requirements_sigma.txt
+++ b/requirements_sigma.txt
@@ -1,1 +1,1 @@
-pySigma>=0.9.5
+pySigma>=0.10.0


### PR DESCRIPTION
Updated Sigma translator for DFE to use the Kusto backend from the following repo: https://github.com/AttackIQ/pySigma-backend-kusto.

How to test:

```
from common import sigma_translation
sigma_translation(
    product = "dfe", 
    sigma_rules=["""
        title: Mimikatz CommandLine
        status: test
        logsource:
            category: process_creation
            product: windows
        detection:
            sel:
                CommandLine|contains: mimikatz.exe
            condition: sel
        """
        ]
    )
```

Output:
```
{'queries': [{'query': 'DeviceProcessEvents\n| where ProcessCommandLine contains "mimikatz.exe"',
   'id': None,
   'title': 'Mimikatz CommandLine',
   'description': None}]}
```