### PR TITLE
Fix missing username for defender for endpoint query

### DIFF
--- a/products/microsoft_defender_for_endpoints.py
+++ b/products/microsoft_defender_for_endpoints.py
@@ -130,8 +130,10 @@ class DefenderForEndpoints(Product):
                         raw_results.append(res)
                     '''
                     hostname = res['DeviceName'] if 'DeviceName' in res else 'Unknown'
+                    
                     if 'AccountName' in res or 'InitiatingProcessAccountName' in res:
                         username = res['AccountName'] if 'AccountName' in res else res['InitiatingProcessAccountName']
+                    else:
                         username = 'Unknown'
                     
                     if 'ProcessCommandLine' in res or 'InitiatingProcessCommandLine' in res:


### PR DESCRIPTION
In the previous version of the code, the username variable was incorrectly overwritten with an empty string immediately after it was assigned. This revision resolves that issue.