### PR TITLE
Add more Mouse Jiggler search terms to screensaverbypass definition file

### DIFF
--- a/definitions/screensaverbypass.json
+++ b/definitions/screensaverbypass.json
@@ -2,8 +2,10 @@
     "Caffeine": {
         "process_name": ["caffeine.exe"]
     },
-    "Mouse Jiggle": {
-        "process_name": ["mousejiggle.exe"]
+    "Mouse Jiggler": {
+        "process_name": ["mousejiggle.exe", "mousejiggler.exe"],
+        "digsig_publisher": ["Alistair Young", "Arkane Systems"],
+        "internal_name": ["MouseJiggler"]
     },
     "Mouse Mover": {
         "process_name": ["move mouse.exe"]


### PR DESCRIPTION
Added more search terms to identify [Mouse Jiggler](https://github.com/arkane-systems/mousejiggler).

When Mouse Jiggler 2.0 was released, the binary name changed from `MouseJiggle.exe` to `MouseJiggler.exe`. The definition file has been updated to detect both versions, along with the different digital signers observed. An internal file name of MouseJiggler has also been added to improve identification in environments.

Fixes #202 

### References:
[Mouse Jiggler – Arkane Systems GitHub](https://github.com/arkane-systems/mousejiggler)